### PR TITLE
DetailVC 완성 🔥

### DIFF
--- a/cozy/Podfile.lock
+++ b/cozy/Podfile.lock
@@ -5,14 +5,12 @@ PODS:
   - Kingfisher/Core (5.14.0)
   - NMapsMap (3.8.0)
   - SwiftLint (0.40.0)
-  - SwiftyOnboard (1.3.8)
 
 DEPENDENCIES:
   - Alamofire (~> 4.8.2)
   - Kingfisher (~> 5.0)
   - NMapsMap
   - SwiftLint
-  - SwiftyOnboard
 
 SPEC REPOS:
   trunk:
@@ -20,15 +18,13 @@ SPEC REPOS:
     - Kingfisher
     - NMapsMap
     - SwiftLint
-    - SwiftyOnboard
 
 SPEC CHECKSUMS:
   Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
   Kingfisher: 7b64389a43139c903ec434788344c288217c792d
   NMapsMap: b3633ad688483a318be9293aeddd323a714fb08b
   SwiftLint: 4154893c73a4c52d6240195507eb7a3e3c64087e
-  SwiftyOnboard: de60e90c2af23dd61b01ec0c6a8d0be3370f857b
 
-PODFILE CHECKSUM: 03d1e14a054aea9e4cf6795e9317b0462a4394ad
+PODFILE CHECKSUM: 950809dc59d5ff9b97bd1c5875e46d527e5c129a
 
 COCOAPODS: 1.9.3

--- a/cozy/cozy.xcodeproj/project.pbxproj
+++ b/cozy/cozy.xcodeproj/project.pbxproj
@@ -59,6 +59,8 @@
 		B6A0BFAE24FC1EAF00D0083D /* MapSelectVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0BFAD24FC1EAF00D0083D /* MapSelectVC.swift */; };
 		B6A0BFB024FC26DD00D0083D /* RegionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0BFAF24FC26DD00D0083D /* RegionCell.swift */; };
 		B6A487AE24F812F50058025C /* MapSelectCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A487AD24F812F50058025C /* MapSelectCell.swift */; };
+		B6B1E1CA24FED56A00E60FB0 /* detailCell3.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B1E1C824FED56A00E60FB0 /* detailCell3.swift */; };
+		B6B1E1CB24FED56A00E60FB0 /* detailCell3.xib in Resources */ = {isa = PBXBuildFile; fileRef = B6B1E1C924FED56A00E60FB0 /* detailCell3.xib */; };
 		B6F4140A24F19B36009863D7 /* NanumSquareRoundL.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B6F4140624F19B36009863D7 /* NanumSquareRoundL.ttf */; };
 		B6F4140B24F19B36009863D7 /* NanumSquareRoundEB.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B6F4140724F19B36009863D7 /* NanumSquareRoundEB.ttf */; };
 		B6F4140C24F19B36009863D7 /* NanumSquareRoundR.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B6F4140824F19B36009863D7 /* NanumSquareRoundR.ttf */; };
@@ -125,6 +127,8 @@
 		B6A0BFAD24FC1EAF00D0083D /* MapSelectVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapSelectVC.swift; sourceTree = "<group>"; };
 		B6A0BFAF24FC26DD00D0083D /* RegionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionCell.swift; sourceTree = "<group>"; };
 		B6A487AD24F812F50058025C /* MapSelectCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapSelectCell.swift; sourceTree = "<group>"; };
+		B6B1E1C824FED56A00E60FB0 /* detailCell3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = detailCell3.swift; sourceTree = "<group>"; };
+		B6B1E1C924FED56A00E60FB0 /* detailCell3.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = detailCell3.xib; sourceTree = "<group>"; };
 		B6F4140624F19B36009863D7 /* NanumSquareRoundL.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = NanumSquareRoundL.ttf; path = ../../../../../../../../../../Library/Fonts/NanumSquareRoundL.ttf; sourceTree = "<group>"; };
 		B6F4140724F19B36009863D7 /* NanumSquareRoundEB.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = NanumSquareRoundEB.ttf; path = ../../../../../../../../../../Library/Fonts/NanumSquareRoundEB.ttf; sourceTree = "<group>"; };
 		B6F4140824F19B36009863D7 /* NanumSquareRoundR.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = NanumSquareRoundR.ttf; path = ../../../../../../../../../../Library/Fonts/NanumSquareRoundR.ttf; sourceTree = "<group>"; };
@@ -440,6 +444,8 @@
 				B6985F1824FAC81B002A3E6B /* detailCell2.swift */,
 				B6985F1924FAC81B002A3E6B /* detailCell2.xib */,
 				187FEED624FCD6AA00476D89 /* DisplayDetailCell.swift */,
+				B6B1E1C824FED56A00E60FB0 /* detailCell3.swift */,
+				B6B1E1C924FED56A00E60FB0 /* detailCell3.xib */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -539,6 +545,7 @@
 				B646AF5124EBFE4C00AC96A9 /* Assets.xcassets in Resources */,
 				B6F4140B24F19B36009863D7 /* NanumSquareRoundEB.ttf in Resources */,
 				B6F4140A24F19B36009863D7 /* NanumSquareRoundL.ttf in Resources */,
+				B6B1E1CB24FED56A00E60FB0 /* detailCell3.xib in Resources */,
 				B649CCF224FAB6AB0032AF31 /* BookDetail.storyboard in Resources */,
 				B646AF7524EC031500AC96A9 /* Activity.storyboard in Resources */,
 				B646AF4C24EBFE4B00AC96A9 /* Main.storyboard in Resources */,
@@ -634,6 +641,7 @@
 				B646AF6824EC00C800AC96A9 /* APIConstants.swift in Sources */,
 				B6F4140F24F1A09B009863D7 /* UIView+Extensions.swift in Sources */,
 				187FEEF224FE964A00476D89 /* vc3.swift in Sources */,
+				B6B1E1CA24FED56A00E60FB0 /* detailCell3.swift in Sources */,
 				B646AF4524EBFE4B00AC96A9 /* AppDelegate.swift in Sources */,
 				187FEED524FCD58600476D89 /* DisplayDetailData.swift in Sources */,
 				B646AF4F24EBFE4B00AC96A9 /* cozy.xcdatamodeld in Sources */,

--- a/cozy/cozy/Resource/Storyboard/Recommend/Recommend.storyboard
+++ b/cozy/cozy/Resource/Storyboard/Recommend/Recommend.storyboard
@@ -107,6 +107,9 @@
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ikb-Mh-zUE">
                                                     <rect key="frame" x="354" y="33" width="14" height="22"/>
                                                     <state key="normal" image="iconsavewhite"/>
+                                                    <connections>
+                                                        <action selector="clickBookmarkButton:" destination="Rt3-y6-dkZ" eventType="touchUpInside" id="gAR-u0-te6"/>
+                                                    </connections>
                                                 </button>
                                             </subviews>
                                             <constraints>

--- a/cozy/cozy/Source/ViewControllers/Map/VC/MapSelectVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Map/VC/MapSelectVC.swift
@@ -23,6 +23,8 @@ class MapSelectVC: UIViewController {
     private let regionIdentifier: String = "regionCell"
     private var isSelectedRegion: Bool = false
 
+    var location: [String] = ["용산구", "마포구", "관악구, 영등포구, 강서구", "광진구, 노원구, 성북구", "서초구, 강남구, 송파구", "서대문구, 종로구"]
+
     override func viewDidLoad() {
         super.viewDidLoad()
         headerView.setViewShadow()
@@ -50,13 +52,13 @@ class MapSelectVC: UIViewController {
 
 extension MapSelectVC: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 6
+        return self.location.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: regionIdentifier) as! RegionCell
         cell.selectionStyle = .none
-        cell.regionLabel.text = "마포구"
+        cell.regionLabel.text = self.location[indexPath.row]
         cell.countLabel.text = "12"
         return cell
     }

--- a/cozy/cozy/Source/ViewControllers/Recommend/Cell/bookstoreCell.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/Cell/bookstoreCell.swift
@@ -8,7 +8,13 @@
 
 import UIKit
 
+protocol bookstoreDelegate: AnyObject {
+    func clickBookmarkButton()
+}
+
 class bookstoreCell: UITableViewCell {
+    
+    weak var delegate: bookstoreDelegate?
 
     @IBOutlet weak var bookstoreImageView: UIImageView!
 
@@ -33,5 +39,9 @@ class bookstoreCell: UITableViewCell {
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
     }
-
+    
+    @IBAction func clickBookmarkButton(_ sender: UIButton) {
+        self.delegate?.clickBookmarkButton()
+    }
+    
 }

--- a/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell1.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell1.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol detailCell1Delegate {
+protocol detailCell1Delegate: AnyObject {
     func selectBookButton()
     func selectActivityButton()
 }
@@ -59,14 +59,14 @@ class detailCell1: UITableViewCell {
     }
 
     @IBAction func selectBookButton(_ sender: UIButton) {
-        self.bookUnderline.isHidden = false
-        self.activityUnderline.isHidden = true
+//        self.bookUnderline.isHidden = false
+//        self.activityUnderline.isHidden = true
         self.delegate?.selectBookButton()
     }
 
     @IBAction func selectActivityButton(_ sender: UIButton) {
-        self.bookUnderline.isHidden = true
-        self.activityUnderline.isHidden = false
+//        self.bookUnderline.isHidden = true
+//        self.activityUnderline.isHidden = false
         self.delegate?.selectActivityButton()
     }
 

--- a/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell1.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell1.swift
@@ -8,7 +8,14 @@
 
 import UIKit
 
+protocol detailCell1Delegate {
+    func selectBookButton()
+    func selectActivityButton()
+}
+
 class detailCell1: UITableViewCell {
+
+    weak var delegate: detailCell1Delegate?
 
     @IBOutlet weak var bookstoreImageView: UIImageView!
 
@@ -49,6 +56,18 @@ class detailCell1: UITableViewCell {
 
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
+    }
+
+    @IBAction func selectBookButton(_ sender: UIButton) {
+        self.bookUnderline.isHidden = false
+        self.activityUnderline.isHidden = true
+        self.delegate?.selectBookButton()
+    }
+
+    @IBAction func selectActivityButton(_ sender: UIButton) {
+        self.bookUnderline.isHidden = true
+        self.activityUnderline.isHidden = false
+        self.delegate?.selectActivityButton()
     }
 
 }

--- a/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell1.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell1.swift
@@ -59,14 +59,10 @@ class detailCell1: UITableViewCell {
     }
 
     @IBAction func selectBookButton(_ sender: UIButton) {
-//        self.bookUnderline.isHidden = false
-//        self.activityUnderline.isHidden = true
         self.delegate?.selectBookButton()
     }
 
     @IBAction func selectActivityButton(_ sender: UIButton) {
-//        self.bookUnderline.isHidden = true
-//        self.activityUnderline.isHidden = false
         self.delegate?.selectActivityButton()
     }
 

--- a/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell1.xib
+++ b/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell1.xib
@@ -159,6 +159,9 @@
                         <state key="normal" title="책방">
                             <color key="titleColor" red="0.33333333329999998" green="0.33333333329999998" blue="0.33333333329999998" alpha="1" colorSpace="calibratedRGB"/>
                         </state>
+                        <connections>
+                            <action selector="selectBookButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="OOI-0Y-fvO"/>
+                        </connections>
                     </button>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2we-ag-JDl">
                         <rect key="frame" x="241" y="635" width="30" height="28"/>
@@ -166,6 +169,9 @@
                         <state key="normal" title="활동">
                             <color key="titleColor" red="0.33333333329999998" green="0.33333333329999998" blue="0.33333333329999998" alpha="1" colorSpace="calibratedRGB"/>
                         </state>
+                        <connections>
+                            <action selector="selectActivityButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="Rs2-0d-7eh"/>
+                        </connections>
                     </button>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uFd-cH-w1n">
                         <rect key="frame" x="50" y="660" width="28" height="2"/>

--- a/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell2.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell2.swift
@@ -10,6 +10,9 @@ import UIKit
 
 class detailCell2: UITableViewCell {
 
+    @IBOutlet weak var detailImageView: UIImageView!
+    @IBOutlet weak var detailLabel: UILabel!
+
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code

--- a/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell2.xib
+++ b/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell2.xib
@@ -22,13 +22,13 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5gw-PF-Rlp">
-                        <rect key="frame" x="24" y="35" width="272" height="303"/>
+                        <rect key="frame" x="24" y="0.0" width="272" height="303"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="303" id="0OU-6F-pzK"/>
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MQ7-1A-Pn2">
-                        <rect key="frame" x="24" y="358" width="272" height="15.5"/>
+                        <rect key="frame" x="24" y="323" width="272" height="15.5"/>
                         <fontDescription key="fontDescription" name="NanumSquareRoundL" family="NanumSquareRound" pointSize="14"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -40,7 +40,7 @@
                     <constraint firstAttribute="trailing" secondItem="MQ7-1A-Pn2" secondAttribute="trailing" constant="24" id="6bk-sS-Rqw"/>
                     <constraint firstItem="MQ7-1A-Pn2" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="24" id="72z-gI-wtc"/>
                     <constraint firstItem="5gw-PF-Rlp" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="24" id="HGY-J4-Rnb"/>
-                    <constraint firstItem="5gw-PF-Rlp" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="35" id="Vif-cj-vCp"/>
+                    <constraint firstItem="5gw-PF-Rlp" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="Vif-cj-vCp"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>

--- a/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell2.xib
+++ b/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell2.xib
@@ -6,17 +6,48 @@
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
+    <customFonts key="customFonts">
+        <array key="NanumSquareRoundL.ttf">
+            <string>NanumSquareRoundL</string>
+        </array>
+    </customFonts>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="detailCell2" customModule="cozy" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="detailCell2" id="KGk-i7-Jjw" customClass="detailCell2" customModule="cozy" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="450"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="450"/>
                 <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5gw-PF-Rlp">
+                        <rect key="frame" x="24" y="35" width="272" height="303"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="303" id="0OU-6F-pzK"/>
+                        </constraints>
+                    </imageView>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MQ7-1A-Pn2">
+                        <rect key="frame" x="24" y="358" width="272" height="15.5"/>
+                        <fontDescription key="fontDescription" name="NanumSquareRoundL" family="NanumSquareRound" pointSize="14"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="5gw-PF-Rlp" secondAttribute="trailing" constant="24" id="0hr-P6-2Z0"/>
+                    <constraint firstItem="MQ7-1A-Pn2" firstAttribute="top" secondItem="5gw-PF-Rlp" secondAttribute="bottom" constant="20" id="4Gp-Cc-E2G"/>
+                    <constraint firstAttribute="trailing" secondItem="MQ7-1A-Pn2" secondAttribute="trailing" constant="24" id="6bk-sS-Rqw"/>
+                    <constraint firstItem="MQ7-1A-Pn2" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="24" id="72z-gI-wtc"/>
+                    <constraint firstItem="5gw-PF-Rlp" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="24" id="HGY-J4-Rnb"/>
+                    <constraint firstItem="5gw-PF-Rlp" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="35" id="Vif-cj-vCp"/>
+                </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="detailImageView" destination="5gw-PF-Rlp" id="8w0-MN-iG2"/>
+                <outlet property="detailLabel" destination="MQ7-1A-Pn2" id="seh-vC-U7G"/>
+            </connections>
             <point key="canvasLocation" x="139" y="153"/>
         </tableViewCell>
     </objects>

--- a/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell3.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell3.swift
@@ -8,7 +8,14 @@
 
 import UIKit
 
+protocol detailCell3Delegate: AnyObject {
+    func clickImageButton1()
+    func clickImageBUtton2()
+}
+
 class detailCell3: UITableViewCell {
+
+    weak var delegate: detailCell3Delegate?
 
     @IBOutlet weak var imageButton1: UIButton!
     @IBOutlet weak var imageButton2: UIButton!
@@ -27,13 +34,18 @@ class detailCell3: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
+    }
 
-        // Configure the view for the selected state
+    @IBAction func clickImageButton1(_ sender: UIButton) {
+        self.delegate?.clickImageButton1()
+    }
+
+    @IBAction func clickImageButton2(_ sender: UIButton) {
+        self.delegate?.clickImageBUtton2()
     }
 
 }

--- a/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell3.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell3.swift
@@ -10,11 +10,11 @@ import UIKit
 
 class detailCell3: UITableViewCell {
 
-    @IBOutlet weak var image1: UIImageView!
-    @IBOutlet weak var image2: UIImageView!
+    @IBOutlet weak var imageButton1: UIButton!
+    @IBOutlet weak var imageButton2: UIButton!
 
-    @IBOutlet weak var dayLabel1: UILabel!
-    @IBOutlet weak var dayLabel2: UILabel!
+    @IBOutlet weak var daycntLabel1: UILabel!
+    @IBOutlet weak var dayCntLabel2: UILabel!
 
     @IBOutlet weak var nameLabel1: UILabel!
     @IBOutlet weak var nameLabel2: UILabel!

--- a/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell3.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell3.swift
@@ -1,0 +1,24 @@
+//
+//  detailCell3.swift
+//  cozy
+//
+//  Created by 최은지 on 2020/09/02.
+//  Copyright © 2020 최은지. All rights reserved.
+//
+
+import UIKit
+
+class detailCell3: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+}

--- a/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell3.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell3.swift
@@ -10,6 +10,21 @@ import UIKit
 
 class detailCell3: UITableViewCell {
 
+    @IBOutlet weak var image1: UIImageView!
+    @IBOutlet weak var image2: UIImageView!
+
+    @IBOutlet weak var dayLabel1: UILabel!
+    @IBOutlet weak var dayLabel2: UILabel!
+
+    @IBOutlet weak var nameLabel1: UILabel!
+    @IBOutlet weak var nameLabel2: UILabel!
+
+    @IBOutlet weak var descripLabel1: UILabel!
+    @IBOutlet weak var descripLabel2: UILabel!
+
+    @IBOutlet weak var priceLabel1: UILabel!
+    @IBOutlet weak var priceLabel2: UILabel!
+
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code

--- a/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell3.xib
+++ b/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell3.xib
@@ -6,18 +6,173 @@
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
+    <customFonts key="customFonts">
+        <array key="NanumSquareRoundB.ttf">
+            <string>NanumSquareRoundB</string>
+        </array>
+        <array key="NanumSquareRoundL.ttf">
+            <string>NanumSquareRoundL</string>
+        </array>
+    </customFonts>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="detailCell3" id="KGk-i7-Jjw" customClass="detailCell3" customModule="cozy" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="352"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="352"/>
                 <autoresizingMask key="autoresizingMask"/>
-                <color key="backgroundColor" red="0.99607843139999996" green="0.6588235294" blue="0.1960784314" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Lfe-SL-Kt4">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="352"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="h5D-Wq-7K4">
+                                <rect key="frame" x="0.0" y="0.0" width="160" height="352"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5OA-25-OWi">
+                                        <rect key="frame" x="24" y="28" width="126" height="126"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="5OA-25-OWi" secondAttribute="height" multiplier="1:1" id="qNY-cY-KVP"/>
+                                        </constraints>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="44S-2U-yCN">
+                                        <rect key="frame" x="24" y="170" width="41" height="18"/>
+                                        <fontDescription key="fontDescription" name="NanumSquareRoundB" family="NanumSquareRound" pointSize="16"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SJq-hS-9Vs">
+                                        <rect key="frame" x="24" y="194" width="34.5" height="15.5"/>
+                                        <fontDescription key="fontDescription" name="NanumSquareRoundL" family="NanumSquareRound" pointSize="14"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jV2-Du-uLm">
+                                        <rect key="frame" x="24" y="294" width="41" height="18"/>
+                                        <fontDescription key="fontDescription" name="NanumSquareRoundB" family="NanumSquareRound" pointSize="16"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bje-SD-06v">
+                                        <rect key="frame" x="34" y="38" width="40" height="24"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ozB-sT-6zK">
+                                                <rect key="frame" x="4.5" y="5.5" width="31" height="13.5"/>
+                                                <fontDescription key="fontDescription" name="NanumSquareRoundB" family="NanumSquareRound" pointSize="12"/>
+                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstItem="ozB-sT-6zK" firstAttribute="centerX" secondItem="Bje-SD-06v" secondAttribute="centerX" id="7ZE-CD-2JQ"/>
+                                            <constraint firstAttribute="height" constant="24" id="Lx4-A8-ePx"/>
+                                            <constraint firstAttribute="width" constant="40" id="UnC-cf-nTu"/>
+                                            <constraint firstItem="ozB-sT-6zK" firstAttribute="centerY" secondItem="Bje-SD-06v" secondAttribute="centerY" id="bce-is-hEQ"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <constraints>
+                                    <constraint firstItem="44S-2U-yCN" firstAttribute="leading" secondItem="h5D-Wq-7K4" secondAttribute="leading" constant="24" id="Bwu-A1-cnC"/>
+                                    <constraint firstItem="5OA-25-OWi" firstAttribute="leading" secondItem="h5D-Wq-7K4" secondAttribute="leading" constant="24" id="Gbg-dR-SBk"/>
+                                    <constraint firstItem="44S-2U-yCN" firstAttribute="top" secondItem="5OA-25-OWi" secondAttribute="bottom" constant="16" id="HSz-Qy-BlI"/>
+                                    <constraint firstItem="SJq-hS-9Vs" firstAttribute="leading" secondItem="h5D-Wq-7K4" secondAttribute="leading" constant="24" id="L8u-eD-hMh"/>
+                                    <constraint firstItem="jV2-Du-uLm" firstAttribute="leading" secondItem="h5D-Wq-7K4" secondAttribute="leading" constant="24" id="Tm8-10-Isq"/>
+                                    <constraint firstItem="SJq-hS-9Vs" firstAttribute="top" secondItem="44S-2U-yCN" secondAttribute="bottom" constant="6" id="Ug7-09-n3k"/>
+                                    <constraint firstItem="5OA-25-OWi" firstAttribute="top" secondItem="h5D-Wq-7K4" secondAttribute="top" constant="28" id="VTZ-W5-ec3"/>
+                                    <constraint firstAttribute="bottom" secondItem="jV2-Du-uLm" secondAttribute="bottom" constant="40" id="aMy-O7-jUl"/>
+                                    <constraint firstItem="5OA-25-OWi" firstAttribute="leading" secondItem="Bje-SD-06v" secondAttribute="trailing" constant="-50" id="gjX-83-Mac"/>
+                                    <constraint firstItem="5OA-25-OWi" firstAttribute="top" secondItem="Bje-SD-06v" secondAttribute="bottom" constant="-34" id="qUN-tE-jdT"/>
+                                    <constraint firstAttribute="trailing" secondItem="5OA-25-OWi" secondAttribute="trailing" constant="10" id="x0Z-Et-H1d"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kki-ZR-xLx">
+                                <rect key="frame" x="160" y="0.0" width="160" height="352"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="QXa-HJ-BnB">
+                                        <rect key="frame" x="10" y="28" width="126" height="126"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="QXa-HJ-BnB" secondAttribute="height" id="a7W-7k-UcS"/>
+                                        </constraints>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jho-nL-4r9">
+                                        <rect key="frame" x="10" y="170" width="41" height="18"/>
+                                        <fontDescription key="fontDescription" name="NanumSquareRoundB" family="NanumSquareRound" pointSize="16"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RU8-JF-6Vw">
+                                        <rect key="frame" x="10" y="194" width="34.5" height="15.5"/>
+                                        <fontDescription key="fontDescription" name="NanumSquareRoundL" family="NanumSquareRound" pointSize="14"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2lT-Mf-pVQ">
+                                        <rect key="frame" x="10" y="294" width="41" height="18"/>
+                                        <fontDescription key="fontDescription" name="NanumSquareRoundB" family="NanumSquareRound" pointSize="16"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uVf-xg-Cg3">
+                                        <rect key="frame" x="20" y="38" width="40" height="24"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W9c-qX-wSa">
+                                                <rect key="frame" x="4.5" y="5.5" width="31" height="13.5"/>
+                                                <fontDescription key="fontDescription" name="NanumSquareRoundB" family="NanumSquareRound" pointSize="12"/>
+                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstItem="W9c-qX-wSa" firstAttribute="centerX" secondItem="uVf-xg-Cg3" secondAttribute="centerX" id="9Iq-Rk-GJ9"/>
+                                            <constraint firstItem="W9c-qX-wSa" firstAttribute="centerY" secondItem="uVf-xg-Cg3" secondAttribute="centerY" id="IQj-bd-Hxt"/>
+                                            <constraint firstAttribute="width" constant="40" id="cOg-OF-2Xi"/>
+                                            <constraint firstAttribute="height" constant="24" id="qYU-2K-QdO"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="QXa-HJ-BnB" secondAttribute="trailing" constant="24" id="5R9-MR-OW0"/>
+                                    <constraint firstItem="QXa-HJ-BnB" firstAttribute="leading" secondItem="uVf-xg-Cg3" secondAttribute="trailing" constant="-50" id="B0j-f5-L6B"/>
+                                    <constraint firstItem="QXa-HJ-BnB" firstAttribute="top" secondItem="Kki-ZR-xLx" secondAttribute="top" constant="28" id="Eah-jq-Q34"/>
+                                    <constraint firstItem="Jho-nL-4r9" firstAttribute="top" secondItem="QXa-HJ-BnB" secondAttribute="bottom" constant="16" id="Ibz-qD-VGD"/>
+                                    <constraint firstItem="QXa-HJ-BnB" firstAttribute="top" secondItem="uVf-xg-Cg3" secondAttribute="bottom" constant="-34" id="Jz8-Ml-wK0"/>
+                                    <constraint firstItem="RU8-JF-6Vw" firstAttribute="top" secondItem="Jho-nL-4r9" secondAttribute="bottom" constant="6" id="NGd-Db-e52"/>
+                                    <constraint firstItem="2lT-Mf-pVQ" firstAttribute="leading" secondItem="Kki-ZR-xLx" secondAttribute="leading" constant="10" id="P13-hH-LMa"/>
+                                    <constraint firstItem="QXa-HJ-BnB" firstAttribute="leading" secondItem="Kki-ZR-xLx" secondAttribute="leading" constant="10" id="TFI-eM-4ek"/>
+                                    <constraint firstItem="RU8-JF-6Vw" firstAttribute="leading" secondItem="Kki-ZR-xLx" secondAttribute="leading" constant="10" id="auC-hc-HXa"/>
+                                    <constraint firstAttribute="bottom" secondItem="2lT-Mf-pVQ" secondAttribute="bottom" constant="40" id="giO-h3-eHV"/>
+                                    <constraint firstItem="Jho-nL-4r9" firstAttribute="leading" secondItem="Kki-ZR-xLx" secondAttribute="leading" constant="10" id="ipY-DP-AA9"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="Lfe-SL-Kt4" secondAttribute="trailing" id="479-bO-EqP"/>
+                    <constraint firstItem="Lfe-SL-Kt4" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="G57-wW-1eb"/>
+                    <constraint firstAttribute="bottom" secondItem="Lfe-SL-Kt4" secondAttribute="bottom" id="LSe-UM-UcW"/>
+                    <constraint firstItem="Lfe-SL-Kt4" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="pYC-I8-MC6"/>
+                </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="dayLabel1" destination="ozB-sT-6zK" id="dwN-Se-lio"/>
+                <outlet property="dayLabel2" destination="W9c-qX-wSa" id="yj1-9b-LLP"/>
+                <outlet property="descripLabel1" destination="SJq-hS-9Vs" id="yZI-X7-31R"/>
+                <outlet property="descripLabel2" destination="RU8-JF-6Vw" id="HnA-yW-74f"/>
+                <outlet property="image1" destination="5OA-25-OWi" id="kD8-mc-eje"/>
+                <outlet property="image2" destination="QXa-HJ-BnB" id="4zj-zZ-TaP"/>
+                <outlet property="nameLabel1" destination="44S-2U-yCN" id="Pqe-bc-ah3"/>
+                <outlet property="nameLabel2" destination="Jho-nL-4r9" id="ddP-DN-wP9"/>
+                <outlet property="priceLabel1" destination="jV2-Du-uLm" id="ZkN-FO-N0N"/>
+                <outlet property="priceLabel2" destination="2lT-Mf-pVQ" id="x1i-LC-G71"/>
+            </connections>
             <point key="canvasLocation" x="137.68115942028987" y="114.50892857142857"/>
         </tableViewCell>
     </objects>

--- a/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell3.xib
+++ b/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell3.xib
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="detailCell3" id="KGk-i7-Jjw" customClass="detailCell3" customModule="cozy" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <color key="backgroundColor" red="0.99607843139999996" green="0.6588235294" blue="0.1960784314" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <point key="canvasLocation" x="137.68115942028987" y="114.50892857142857"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell3.xib
+++ b/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell3.xib
@@ -30,20 +30,14 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="h5D-Wq-7K4">
                                 <rect key="frame" x="0.0" y="0.0" width="160" height="352"/>
                                 <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5OA-25-OWi">
-                                        <rect key="frame" x="24" y="28" width="126" height="126"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="5OA-25-OWi" secondAttribute="height" multiplier="1:1" id="qNY-cY-KVP"/>
-                                        </constraints>
-                                    </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="44S-2U-yCN">
-                                        <rect key="frame" x="24" y="170" width="41" height="18"/>
+                                        <rect key="frame" x="24" y="142" width="41" height="18"/>
                                         <fontDescription key="fontDescription" name="NanumSquareRoundB" family="NanumSquareRound" pointSize="16"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SJq-hS-9Vs">
-                                        <rect key="frame" x="24" y="194" width="34.5" height="15.5"/>
+                                        <rect key="frame" x="24" y="166" width="34.5" height="15.5"/>
                                         <fontDescription key="fontDescription" name="NanumSquareRoundL" family="NanumSquareRound" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -54,57 +48,51 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bje-SD-06v">
-                                        <rect key="frame" x="34" y="38" width="40" height="24"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ozB-sT-6zK">
-                                                <rect key="frame" x="4.5" y="5.5" width="31" height="13.5"/>
-                                                <fontDescription key="fontDescription" name="NanumSquareRoundB" family="NanumSquareRound" pointSize="12"/>
-                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8xt-Xd-Qys">
+                                        <rect key="frame" x="24" y="0.0" width="126" height="126"/>
+                                        <color key="backgroundColor" red="0.96862745100000003" green="0.96470588239999999" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="8xt-Xd-Qys" secondAttribute="height" id="RJH-dg-Q8F"/>
+                                        </constraints>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VIH-VD-LPS">
+                                        <rect key="frame" x="34" y="10" width="40" height="24"/>
                                         <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
-                                            <constraint firstItem="ozB-sT-6zK" firstAttribute="centerX" secondItem="Bje-SD-06v" secondAttribute="centerX" id="7ZE-CD-2JQ"/>
-                                            <constraint firstAttribute="height" constant="24" id="Lx4-A8-ePx"/>
-                                            <constraint firstAttribute="width" constant="40" id="UnC-cf-nTu"/>
-                                            <constraint firstItem="ozB-sT-6zK" firstAttribute="centerY" secondItem="Bje-SD-06v" secondAttribute="centerY" id="bce-is-hEQ"/>
+                                            <constraint firstAttribute="height" constant="24" id="2RX-j6-MOw"/>
+                                            <constraint firstAttribute="width" constant="40" id="cOU-a0-egq"/>
                                         </constraints>
-                                    </view>
+                                        <fontDescription key="fontDescription" name="NanumSquareRoundB" family="NanumSquareRound" pointSize="12"/>
+                                        <color key="textColor" red="0.96862745100000003" green="0.96470588239999999" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
+                                    <constraint firstItem="VIH-VD-LPS" firstAttribute="leading" secondItem="h5D-Wq-7K4" secondAttribute="leading" constant="34" id="0N8-Dn-0R2"/>
+                                    <constraint firstItem="8xt-Xd-Qys" firstAttribute="leading" secondItem="h5D-Wq-7K4" secondAttribute="leading" constant="24" id="8Ay-YV-eHB"/>
                                     <constraint firstItem="44S-2U-yCN" firstAttribute="leading" secondItem="h5D-Wq-7K4" secondAttribute="leading" constant="24" id="Bwu-A1-cnC"/>
-                                    <constraint firstItem="5OA-25-OWi" firstAttribute="leading" secondItem="h5D-Wq-7K4" secondAttribute="leading" constant="24" id="Gbg-dR-SBk"/>
-                                    <constraint firstItem="44S-2U-yCN" firstAttribute="top" secondItem="5OA-25-OWi" secondAttribute="bottom" constant="16" id="HSz-Qy-BlI"/>
+                                    <constraint firstAttribute="trailing" secondItem="8xt-Xd-Qys" secondAttribute="trailing" constant="10" id="K2c-NT-iBR"/>
                                     <constraint firstItem="SJq-hS-9Vs" firstAttribute="leading" secondItem="h5D-Wq-7K4" secondAttribute="leading" constant="24" id="L8u-eD-hMh"/>
+                                    <constraint firstItem="8xt-Xd-Qys" firstAttribute="top" secondItem="h5D-Wq-7K4" secondAttribute="top" id="Ptl-Qa-OjZ"/>
+                                    <constraint firstItem="44S-2U-yCN" firstAttribute="top" secondItem="8xt-Xd-Qys" secondAttribute="bottom" constant="16" id="TMb-sM-5bi"/>
                                     <constraint firstItem="jV2-Du-uLm" firstAttribute="leading" secondItem="h5D-Wq-7K4" secondAttribute="leading" constant="24" id="Tm8-10-Isq"/>
                                     <constraint firstItem="SJq-hS-9Vs" firstAttribute="top" secondItem="44S-2U-yCN" secondAttribute="bottom" constant="6" id="Ug7-09-n3k"/>
-                                    <constraint firstItem="5OA-25-OWi" firstAttribute="top" secondItem="h5D-Wq-7K4" secondAttribute="top" constant="28" id="VTZ-W5-ec3"/>
                                     <constraint firstAttribute="bottom" secondItem="jV2-Du-uLm" secondAttribute="bottom" constant="40" id="aMy-O7-jUl"/>
-                                    <constraint firstItem="5OA-25-OWi" firstAttribute="leading" secondItem="Bje-SD-06v" secondAttribute="trailing" constant="-50" id="gjX-83-Mac"/>
-                                    <constraint firstItem="5OA-25-OWi" firstAttribute="top" secondItem="Bje-SD-06v" secondAttribute="bottom" constant="-34" id="qUN-tE-jdT"/>
-                                    <constraint firstAttribute="trailing" secondItem="5OA-25-OWi" secondAttribute="trailing" constant="10" id="x0Z-Et-H1d"/>
+                                    <constraint firstItem="VIH-VD-LPS" firstAttribute="top" secondItem="h5D-Wq-7K4" secondAttribute="top" constant="10" id="eeQ-TK-WBF"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kki-ZR-xLx">
                                 <rect key="frame" x="160" y="0.0" width="160" height="352"/>
                                 <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="QXa-HJ-BnB">
-                                        <rect key="frame" x="10" y="28" width="126" height="126"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="QXa-HJ-BnB" secondAttribute="height" id="a7W-7k-UcS"/>
-                                        </constraints>
-                                    </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jho-nL-4r9">
-                                        <rect key="frame" x="10" y="170" width="41" height="18"/>
+                                        <rect key="frame" x="10" y="142" width="41" height="18"/>
                                         <fontDescription key="fontDescription" name="NanumSquareRoundB" family="NanumSquareRound" pointSize="16"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RU8-JF-6Vw">
-                                        <rect key="frame" x="10" y="194" width="34.5" height="15.5"/>
+                                        <rect key="frame" x="10" y="166" width="34.5" height="15.5"/>
                                         <fontDescription key="fontDescription" name="NanumSquareRoundL" family="NanumSquareRound" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -115,41 +103,43 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uVf-xg-Cg3">
-                                        <rect key="frame" x="20" y="38" width="40" height="24"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W9c-qX-wSa">
-                                                <rect key="frame" x="4.5" y="5.5" width="31" height="13.5"/>
-                                                <fontDescription key="fontDescription" name="NanumSquareRoundB" family="NanumSquareRound" pointSize="12"/>
-                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="s1n-wQ-hJw">
+                                        <rect key="frame" x="10" y="0.0" width="126" height="126"/>
+                                        <color key="backgroundColor" red="0.96862745100000003" green="0.96470588239999999" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="s1n-wQ-hJw" secondAttribute="height" multiplier="1:1" id="5fq-h5-6Qd"/>
+                                        </constraints>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tZ7-jk-Zit">
+                                        <rect key="frame" x="20" y="10" width="40" height="24"/>
                                         <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
-                                            <constraint firstItem="W9c-qX-wSa" firstAttribute="centerX" secondItem="uVf-xg-Cg3" secondAttribute="centerX" id="9Iq-Rk-GJ9"/>
-                                            <constraint firstItem="W9c-qX-wSa" firstAttribute="centerY" secondItem="uVf-xg-Cg3" secondAttribute="centerY" id="IQj-bd-Hxt"/>
-                                            <constraint firstAttribute="width" constant="40" id="cOg-OF-2Xi"/>
-                                            <constraint firstAttribute="height" constant="24" id="qYU-2K-QdO"/>
+                                            <constraint firstAttribute="width" constant="40" id="oq7-o2-lt8"/>
+                                            <constraint firstAttribute="height" constant="24" id="p3r-ex-Mm3"/>
                                         </constraints>
-                                    </view>
+                                        <fontDescription key="fontDescription" name="NanumSquareRoundB" family="NanumSquareRound" pointSize="12"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="QXa-HJ-BnB" secondAttribute="trailing" constant="24" id="5R9-MR-OW0"/>
-                                    <constraint firstItem="QXa-HJ-BnB" firstAttribute="leading" secondItem="uVf-xg-Cg3" secondAttribute="trailing" constant="-50" id="B0j-f5-L6B"/>
-                                    <constraint firstItem="QXa-HJ-BnB" firstAttribute="top" secondItem="Kki-ZR-xLx" secondAttribute="top" constant="28" id="Eah-jq-Q34"/>
-                                    <constraint firstItem="Jho-nL-4r9" firstAttribute="top" secondItem="QXa-HJ-BnB" secondAttribute="bottom" constant="16" id="Ibz-qD-VGD"/>
-                                    <constraint firstItem="QXa-HJ-BnB" firstAttribute="top" secondItem="uVf-xg-Cg3" secondAttribute="bottom" constant="-34" id="Jz8-Ml-wK0"/>
+                                    <constraint firstItem="s1n-wQ-hJw" firstAttribute="top" secondItem="Kki-ZR-xLx" secondAttribute="top" id="BiH-C7-YuM"/>
                                     <constraint firstItem="RU8-JF-6Vw" firstAttribute="top" secondItem="Jho-nL-4r9" secondAttribute="bottom" constant="6" id="NGd-Db-e52"/>
+                                    <constraint firstAttribute="trailing" secondItem="s1n-wQ-hJw" secondAttribute="trailing" constant="24" id="NRt-5Q-I2S"/>
                                     <constraint firstItem="2lT-Mf-pVQ" firstAttribute="leading" secondItem="Kki-ZR-xLx" secondAttribute="leading" constant="10" id="P13-hH-LMa"/>
-                                    <constraint firstItem="QXa-HJ-BnB" firstAttribute="leading" secondItem="Kki-ZR-xLx" secondAttribute="leading" constant="10" id="TFI-eM-4ek"/>
+                                    <constraint firstItem="s1n-wQ-hJw" firstAttribute="leading" secondItem="Kki-ZR-xLx" secondAttribute="leading" constant="10" id="PlA-li-pRU"/>
                                     <constraint firstItem="RU8-JF-6Vw" firstAttribute="leading" secondItem="Kki-ZR-xLx" secondAttribute="leading" constant="10" id="auC-hc-HXa"/>
                                     <constraint firstAttribute="bottom" secondItem="2lT-Mf-pVQ" secondAttribute="bottom" constant="40" id="giO-h3-eHV"/>
                                     <constraint firstItem="Jho-nL-4r9" firstAttribute="leading" secondItem="Kki-ZR-xLx" secondAttribute="leading" constant="10" id="ipY-DP-AA9"/>
+                                    <constraint firstItem="tZ7-jk-Zit" firstAttribute="leading" secondItem="Kki-ZR-xLx" secondAttribute="leading" constant="20" id="nAl-i1-UfN"/>
+                                    <constraint firstItem="Jho-nL-4r9" firstAttribute="top" secondItem="s1n-wQ-hJw" secondAttribute="bottom" constant="16" id="q55-zf-4KK"/>
                                 </constraints>
                             </view>
                         </subviews>
+                        <constraints>
+                            <constraint firstItem="tZ7-jk-Zit" firstAttribute="centerY" secondItem="VIH-VD-LPS" secondAttribute="centerY" id="eJ2-W2-wiI"/>
+                        </constraints>
                     </stackView>
                 </subviews>
                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -162,12 +152,12 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
-                <outlet property="dayLabel1" destination="ozB-sT-6zK" id="dwN-Se-lio"/>
-                <outlet property="dayLabel2" destination="W9c-qX-wSa" id="yj1-9b-LLP"/>
+                <outlet property="dayCntLabel2" destination="tZ7-jk-Zit" id="JIp-6R-aKT"/>
+                <outlet property="daycntLabel1" destination="VIH-VD-LPS" id="tY5-bt-WUo"/>
                 <outlet property="descripLabel1" destination="SJq-hS-9Vs" id="yZI-X7-31R"/>
                 <outlet property="descripLabel2" destination="RU8-JF-6Vw" id="HnA-yW-74f"/>
-                <outlet property="image1" destination="5OA-25-OWi" id="kD8-mc-eje"/>
-                <outlet property="image2" destination="QXa-HJ-BnB" id="4zj-zZ-TaP"/>
+                <outlet property="imageButton1" destination="8xt-Xd-Qys" id="tw1-Yr-lkB"/>
+                <outlet property="imageButton2" destination="s1n-wQ-hJw" id="goB-oj-4en"/>
                 <outlet property="nameLabel1" destination="44S-2U-yCN" id="Pqe-bc-ah3"/>
                 <outlet property="nameLabel2" destination="Jho-nL-4r9" id="ddP-DN-wP9"/>
                 <outlet property="priceLabel1" destination="jV2-Du-uLm" id="ZkN-FO-N0N"/>

--- a/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell3.xib
+++ b/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell3.xib
@@ -54,6 +54,9 @@
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="8xt-Xd-Qys" secondAttribute="height" id="RJH-dg-Q8F"/>
                                         </constraints>
+                                        <connections>
+                                            <action selector="clickImageButton1:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="4GV-TV-Ymc"/>
+                                        </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VIH-VD-LPS">
                                         <rect key="frame" x="34" y="10" width="40" height="24"/>
@@ -109,6 +112,9 @@
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="s1n-wQ-hJw" secondAttribute="height" multiplier="1:1" id="5fq-h5-6Qd"/>
                                         </constraints>
+                                        <connections>
+                                            <action selector="clickImageButton2:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="MEe-Tj-sTZ"/>
+                                        </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tZ7-jk-Zit">
                                         <rect key="frame" x="20" y="10" width="40" height="24"/>

--- a/cozy/cozy/Source/ViewControllers/Recommend/VC/ActivityRecommendVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/VC/ActivityRecommendVC.swift
@@ -39,6 +39,8 @@ class ActivityRecommendVC: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        setNav()
+
         subImgCollectionView.delegate = self
         subImgCollectionView.dataSource = self
 
@@ -47,6 +49,17 @@ class ActivityRecommendVC: UIViewController {
         setLabelStyle()
         setLabelData()
         setButtonStyle()
+    }
+
+    func setNav() {
+        self.navigationItem.setHidesBackButton(true, animated: true)
+        self.navigationController?.navigationBar.tintColor = UIColor.gray
+        let backButton = UIBarButtonItem(image: UIImage(named: "iconbefore"), style: .plain, target: self, action: #selector(goBack))
+        self.navigationItem.leftBarButtonItem = backButton
+    }
+
+    @objc func goBack() {
+        self.navigationController?.popViewController(animated: true)
     }
 
     //sample data

--- a/cozy/cozy/Source/ViewControllers/Recommend/VC/BookDetailVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/VC/BookDetailVC.swift
@@ -12,6 +12,7 @@ class BookDetailVC: UIViewController {
 
     private let detailIdentifier1: String = "detailCell1"
     private let detailIdentifier2: String = "detailCell2"
+    private let detailIdentifier3: String = "detailCell3"
 
     @IBOutlet weak var detailTableView: UITableView!
 
@@ -22,8 +23,10 @@ class BookDetailVC: UIViewController {
         setNav()
         let detailNib1 = UINib(nibName: "detailCell1", bundle: nil)
         let detailNib2 = UINib(nibName: "detailCell2", bundle: nil)
+        let detailNib3 = UINib(nibName: "detailCell3", bundle: nil)
         detailTableView.register(detailNib1, forCellReuseIdentifier: detailIdentifier1)
         detailTableView.register(detailNib2, forCellReuseIdentifier: detailIdentifier2)
+        detailTableView.register(detailNib3, forCellReuseIdentifier: detailIdentifier3)
 
         detailTableView.delegate = self
         detailTableView.dataSource = self
@@ -45,13 +48,11 @@ extension BookDetailVC: UITableViewDelegate, UITableViewDataSource, detailCell1D
     func selectBookButton() {
         isClickBook = true
         self.detailTableView.reloadData()
-        print("select book button")
     }
 
     func selectActivityButton() {
         isClickBook = false
         self.detailTableView.reloadData()
-        print("select activity button")
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {
@@ -119,9 +120,14 @@ extension BookDetailVC: UITableViewDelegate, UITableViewDataSource, detailCell1D
 
             return cell
         } else {
-            let cell = tableView.dequeueReusableCell(withIdentifier: detailIdentifier2) as! detailCell2
-            cell.detailImageView.image = UIImage(named: "tuBongHKmBzQDkvgIUnsplash")
-            return cell
+            if isClickBook {
+                let cell = tableView.dequeueReusableCell(withIdentifier: detailIdentifier2) as! detailCell2
+                cell.detailImageView.image = UIImage(named: "tuBongHKmBzQDkvgIUnsplash")
+                return cell
+            } else {
+                let cell = tableView.dequeueReusableCell(withIdentifier: detailIdentifier3) as! detailCell3
+                return cell
+            }
         }
     }
 }

--- a/cozy/cozy/Source/ViewControllers/Recommend/VC/BookDetailVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/VC/BookDetailVC.swift
@@ -15,6 +15,8 @@ class BookDetailVC: UIViewController {
 
     @IBOutlet weak var detailTableView: UITableView!
 
+    var isClickBook: Bool = true
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setNav()
@@ -41,10 +43,14 @@ class BookDetailVC: UIViewController {
 
 extension BookDetailVC: UITableViewDelegate, UITableViewDataSource, detailCell1Delegate {
     func selectBookButton() {
+        isClickBook = true
+        self.detailTableView.reloadData()
         print("select book button")
     }
 
     func selectActivityButton() {
+        isClickBook = false
+        self.detailTableView.reloadData()
         print("select activity button")
     }
 
@@ -56,7 +62,7 @@ extension BookDetailVC: UITableViewDelegate, UITableViewDataSource, detailCell1D
         if section == 0 {
             return 1
         } else {
-            return 1
+            return 3
         }
     }
 
@@ -64,7 +70,7 @@ extension BookDetailVC: UITableViewDelegate, UITableViewDataSource, detailCell1D
         if indexPath.section == 0 {
             return 701
         } else {
-            return 100
+            return 450
         }
     }
 
@@ -103,11 +109,18 @@ extension BookDetailVC: UITableViewDelegate, UITableViewDataSource, detailCell1D
 
             cell.homeLabel.text = "공간 대여, 워크샵, 온라인 서점"
 
-            cell.activityUnderline.isHidden = true
+            if isClickBook {
+                cell.bookUnderline.isHidden = false
+                cell.activityUnderline.isHidden = true
+            } else {
+                cell.bookUnderline.isHidden = true
+                cell.activityUnderline.isHidden = false
+            }
 
             return cell
         } else {
             let cell = tableView.dequeueReusableCell(withIdentifier: detailIdentifier2) as! detailCell2
+            cell.detailImageView.image = UIImage(named: "tuBongHKmBzQDkvgIUnsplash")
             return cell
         }
     }

--- a/cozy/cozy/Source/ViewControllers/Recommend/VC/BookDetailVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/VC/BookDetailVC.swift
@@ -44,7 +44,19 @@ class BookDetailVC: UIViewController {
     }
 }
 
-extension BookDetailVC: UITableViewDelegate, UITableViewDataSource, detailCell1Delegate {
+extension BookDetailVC: UITableViewDelegate, UITableViewDataSource, detailCell1Delegate, detailCell3Delegate {
+    func clickImageButton1() {
+        let sb = UIStoryboard(name: "ActivityRecommend", bundle: nil)
+        let vc = sb.instantiateViewController(withIdentifier: "ActivityRecommendVC") as! ActivityRecommendVC
+        self.navigationController?.pushViewController(vc, animated: true)
+    }
+
+    func clickImageBUtton2() {
+        let sb = UIStoryboard(name: "ActivityRecommend", bundle: nil)
+        let vc = sb.instantiateViewController(withIdentifier: "ActivityRecommendVC") as! ActivityRecommendVC
+        self.navigationController?.pushViewController(vc, animated: true)
+    }
+
     func selectBookButton() {
         isClickBook = true
         self.detailTableView.reloadData()
@@ -132,6 +144,7 @@ extension BookDetailVC: UITableViewDelegate, UITableViewDataSource, detailCell1D
             } else {
                 let cell = tableView.dequeueReusableCell(withIdentifier: detailIdentifier3) as! detailCell3
                 cell.selectionStyle = .none
+                cell.delegate = self
 
                 cell.imageButton1.setBackgroundImage(UIImage(named: "ajeetMestryUBhpOiHnazMUnsplash"), for: .normal)
                 cell.imageButton2.setBackgroundImage(UIImage(named: "ajeetMestryUBhpOiHnazMUnsplash"), for: .normal)

--- a/cozy/cozy/Source/ViewControllers/Recommend/VC/BookDetailVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/VC/BookDetailVC.swift
@@ -39,7 +39,15 @@ class BookDetailVC: UIViewController {
     }
 }
 
-extension BookDetailVC: UITableViewDelegate, UITableViewDataSource {
+extension BookDetailVC: UITableViewDelegate, UITableViewDataSource, detailCell1Delegate {
+    func selectBookButton() {
+        print("select book button")
+    }
+
+    func selectActivityButton() {
+        print("select activity button")
+    }
+
     func numberOfSections(in tableView: UITableView) -> Int {
         return 2
     }
@@ -63,6 +71,8 @@ extension BookDetailVC: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if indexPath.section == 0 {
             let cell = tableView.dequeueReusableCell(withIdentifier: detailIdentifier1) as! detailCell1
+            cell.selectionStyle = .none
+            cell.delegate = self
 
             cell.bookstoreImageView.image = UIImage(named: "image1")
             cell.bossImageView.image = UIImage(named: "74966Cd691014Bbbf2E445Bbc67Cddbc")

--- a/cozy/cozy/Source/ViewControllers/Recommend/VC/BookDetailVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/VC/BookDetailVC.swift
@@ -71,7 +71,11 @@ extension BookDetailVC: UITableViewDelegate, UITableViewDataSource, detailCell1D
         if indexPath.section == 0 {
             return 701
         } else {
-            return 450
+            if self.isClickBook {
+                return 450
+            } else {
+                return 350
+            }
         }
     }
 
@@ -122,10 +126,24 @@ extension BookDetailVC: UITableViewDelegate, UITableViewDataSource, detailCell1D
         } else {
             if isClickBook {
                 let cell = tableView.dequeueReusableCell(withIdentifier: detailIdentifier2) as! detailCell2
+                cell.selectionStyle = .none
                 cell.detailImageView.image = UIImage(named: "tuBongHKmBzQDkvgIUnsplash")
                 return cell
             } else {
                 let cell = tableView.dequeueReusableCell(withIdentifier: detailIdentifier3) as! detailCell3
+                cell.selectionStyle = .none
+
+                cell.image1.image = UIImage(named: "ajeetMestryUBhpOiHnazMUnsplash")
+                cell.image2.image = UIImage(named: "ajeetMestryUBhpOiHnazMUnsplash")
+                cell.nameLabel1.text = "책방 영화관"
+                cell.nameLabel2.text = "책방 영화관"
+                cell.descripLabel1.text = "대표 책방 영화관"
+                cell.descripLabel2.text = "대표 책방 영화관"
+                cell.dayLabel1.text = "D-3"
+                cell.dayLabel2.text = "D-4"
+                cell.priceLabel1.text = "16,000 원"
+                cell.priceLabel2.text = "16,000 원"
+
                 return cell
             }
         }

--- a/cozy/cozy/Source/ViewControllers/Recommend/VC/BookDetailVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/VC/BookDetailVC.swift
@@ -133,14 +133,14 @@ extension BookDetailVC: UITableViewDelegate, UITableViewDataSource, detailCell1D
                 let cell = tableView.dequeueReusableCell(withIdentifier: detailIdentifier3) as! detailCell3
                 cell.selectionStyle = .none
 
-                cell.image1.image = UIImage(named: "ajeetMestryUBhpOiHnazMUnsplash")
-                cell.image2.image = UIImage(named: "ajeetMestryUBhpOiHnazMUnsplash")
+                cell.imageButton1.setBackgroundImage(UIImage(named: "ajeetMestryUBhpOiHnazMUnsplash"), for: .normal)
+                cell.imageButton2.setBackgroundImage(UIImage(named: "ajeetMestryUBhpOiHnazMUnsplash"), for: .normal)
                 cell.nameLabel1.text = "책방 영화관"
                 cell.nameLabel2.text = "책방 영화관"
                 cell.descripLabel1.text = "대표 책방 영화관"
                 cell.descripLabel2.text = "대표 책방 영화관"
-                cell.dayLabel1.text = "D-3"
-                cell.dayLabel2.text = "D-4"
+                cell.daycntLabel1.text = "D-3"
+                cell.dayCntLabel2.text = "D-4"
                 cell.priceLabel1.text = "16,000 원"
                 cell.priceLabel2.text = "16,000 원"
 

--- a/cozy/cozy/Source/ViewControllers/Recommend/VC/RecommendVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/VC/RecommendVC.swift
@@ -30,8 +30,12 @@ class RecommendVC: UIViewController {
     }
 }
 
-extension RecommendVC: UITableViewDelegate, UITableViewDataSource {
-
+extension RecommendVC: UITableViewDelegate, UITableViewDataSource, bookstoreDelegate {
+    
+    func clickBookmarkButton() {
+        // 북마크 버튼 클릭 이벤트
+    }
+    
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let sb = UIStoryboard(name: "BookDetail", bundle: nil)
         let vc = sb.instantiateViewController(identifier: "BookDetailVC") as! BookDetailVC
@@ -82,6 +86,7 @@ extension RecommendVC: UITableViewDelegate, UITableViewDataSource {
         } else {
             let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier2) as! bookstoreCell
             cell.selectionStyle = .none
+            cell.delegate = self
 
             cell.bookstoreImageView.image = UIImage(named: "image1")
 


### PR DESCRIPTION
detailVC 드디어 완성했습니다..!!

1. 스크롤뷰를 사용해야 하나 고민했지만 책방 소개 내용이 유동적으로 바뀌어야 해서 테이블뷰를 section 별로 나누어 처리했습니다. 모두 Nib을 사용했습니다. 헷갈리지 않고 편합니다.

2. cell 안의 버튼 처리는 **delegate 패턴** 을 사용해 구현했습니다. 책방-활동 버튼 액션에 따라 밑에 리턴 되어야 하는 cell 을 다르게 주어 탭바처럼 보이도록 했습니다. 익숙해지면 정말 편한 방법이니 풀 받아서 나중에 확인해주세요!

3. 활동 탭에서 이미지를 누르면 재드래곤이 만든 ActivityRecommendVC로 넘어가도록 했습니다. 이제서야 추천탭이 어느정도 윤곽이 잡혔습니다ㅠㅠ @didwodnr123 활동 탭에서 테스트 버튼 이제 삭제해주세요!

짜잘한 버그들과 팝업뷰가 아직 남았습니다. 오늘 밤이나 내일 새벽에 끝내고 PR 보내는 것이 목표,,^^
