### PR TITLE
detail API 연결, 로그인유저 구분

### DIFF
--- a/cozy/cozy.xcodeproj/project.pbxproj
+++ b/cozy/cozy.xcodeproj/project.pbxproj
@@ -56,6 +56,8 @@
 		B649CCF424FAB6C80032AF31 /* BookDetailVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = B649CCF324FAB6C80032AF31 /* BookDetailVC.swift */; };
 		B64AF18F24FD5C100015F2A7 /* OnboardingVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = B64AF18E24FD5C100015F2A7 /* OnboardingVC.swift */; };
 		B64AF19224FD5C270015F2A7 /* Onboarding.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B64AF19124FD5C270015F2A7 /* Onboarding.storyboard */; };
+		B65058442507FB8F00D832E1 /* UpdateInterestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65058432507FB8F00D832E1 /* UpdateInterestModel.swift */; };
+		B65058462507FC1700D832E1 /* UpdateInterestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65058452507FC1700D832E1 /* UpdateInterestService.swift */; };
 		B658A3A9250152C40076BCD4 /* OnboardingIntro.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B658A3A8250152C40076BCD4 /* OnboardingIntro.storyboard */; };
 		B658A3AB250152DA0076BCD4 /* OnboardingIntroVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = B658A3AA250152DA0076BCD4 /* OnboardingIntroVC.swift */; };
 		B658A3AD250154690076BCD4 /* OnboardingSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B658A3AC250154690076BCD4 /* OnboardingSlider.swift */; };
@@ -155,6 +157,8 @@
 		B649CCF324FAB6C80032AF31 /* BookDetailVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookDetailVC.swift; sourceTree = "<group>"; };
 		B64AF18E24FD5C100015F2A7 /* OnboardingVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingVC.swift; sourceTree = "<group>"; };
 		B64AF19124FD5C270015F2A7 /* Onboarding.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Onboarding.storyboard; sourceTree = "<group>"; };
+		B65058432507FB8F00D832E1 /* UpdateInterestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateInterestModel.swift; sourceTree = "<group>"; };
+		B65058452507FC1700D832E1 /* UpdateInterestService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateInterestService.swift; sourceTree = "<group>"; };
 		B658A3A8250152C40076BCD4 /* OnboardingIntro.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = OnboardingIntro.storyboard; sourceTree = "<group>"; };
 		B658A3AA250152DA0076BCD4 /* OnboardingIntroVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingIntroVC.swift; sourceTree = "<group>"; };
 		B658A3AC250154690076BCD4 /* OnboardingSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSlider.swift; sourceTree = "<group>"; };
@@ -592,6 +596,7 @@
 				B6208CA025066C2300185624 /* MapCountService.swift */,
 				B6208CA4250675BB00185624 /* MapListService.swift */,
 				B631283525075D66003D33E3 /* KakaoLoginService.swift */,
+				B65058452507FC1700D832E1 /* UpdateInterestService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -608,6 +613,7 @@
 				B6208CA2250674E100185624 /* MapListModel.swift */,
 				CCBBD2DC25073FE4006A73FA /* NoticeModel.swift */,
 				B631283325075C01003D33E3 /* KakaoLoginModel.swift */,
+				B65058432507FB8F00D832E1 /* UpdateInterestModel.swift */,
 			);
 			path = ResponseModel;
 			sourceTree = "<group>";
@@ -811,6 +817,7 @@
 				B646AF4724EBFE4B00AC96A9 /* SceneDelegate.swift in Sources */,
 				B646AF6A24EC00E900AC96A9 /* NetworkResult.swift in Sources */,
 				B658A3B1250156780076BCD4 /* onboardcell1.swift in Sources */,
+				B65058442507FB8F00D832E1 /* UpdateInterestModel.swift in Sources */,
 				CCBBD2DB25072A6F006A73FA /* noticeContentCell.swift in Sources */,
 				B6F4141124F1A256009863D7 /* UIButton+Extensions.swift in Sources */,
 				B631283625075D66003D33E3 /* KakaoLoginService.swift in Sources */,
@@ -833,6 +840,7 @@
 				187C13082506559D004FD60B /* RecommendActivityModel.swift in Sources */,
 				B64940A724F186380052A21F /* MypageNavController.swift in Sources */,
 				187C130425064F88004FD60B /* RecommendFeedService.swift in Sources */,
+				B65058462507FC1700D832E1 /* UpdateInterestService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/cozy/cozy/Source/API/ResponseModel/UpdateInterestModel.swift
+++ b/cozy/cozy/Source/API/ResponseModel/UpdateInterestModel.swift
@@ -1,18 +1,19 @@
 //
-//  RecommendFeedModel.swift
+//  AddInterestModel.swift
 //  cozy
 //
-//  Created by 양재욱 on 2020/09/07.
+//  Created by 최은지 on 2020/09/09.
 //  Copyright © 2020 최은지. All rights reserved.
 //
 
 import Foundation
+import UIKit
 
-struct RecommendFeedModel: Codable {
+struct UpdateInterestModel: Codable {
     var status: Int
     var success: Bool
     var message: String
-    var data: [RecommendFeedData]?
+    var data: UpdateInterestData?
 
     enum CodingKeys: String, CodingKey {
         case status = "status"
@@ -26,16 +27,14 @@ struct RecommendFeedModel: Codable {
         status = (try? values.decode(Int.self, forKey: .status)) ?? -1
         success = (try? values.decode(Bool.self, forKey: .success)) ?? false
         message = (try? values.decode(String.self, forKey: .message)) ?? ""
-        data = (try? values.decode([RecommendFeedData].self, forKey: .data)) ?? nil
+        data = (try? values.decode(UpdateInterestData.self, forKey: .data)) ?? nil
     }
 }
 
-struct RecommendFeedData: Codable {
-    var image: String?
-    var text: String?
+struct UpdateInterestData: Codable {
+    var checked: Int
 
-    init(image: String, text: String) {
-        self.image = image
-        self.text = text
+    init(checked: Int) {
+        self.checked = checked
     }
 }

--- a/cozy/cozy/Source/API/Services/BookstoreDetailService.swift
+++ b/cozy/cozy/Source/API/Services/BookstoreDetailService.swift
@@ -30,6 +30,29 @@ struct BookstoreDetailService {
         }
     }
 
+    func getBookstoreDetailDataWithLogin(bookstoreIdx: Int, completion: @escaping (NetworkResult<Any>) -> Void) {
+
+        guard let token = UserDefaults.standard.string(forKey: "token") else { return }
+        let header: HTTPHeaders = [
+            "Content-Type": "application/json",
+            "token": token
+        ]
+
+        let dataRequest = AF.request(APIConstants.recommendDetailURL + String(bookstoreIdx), method: .get, encoding: JSONEncoding.default, headers: header)
+
+        dataRequest.responseData { dataResponse in
+            switch dataResponse.result {
+            case .success:
+                guard let statusCode = dataResponse.response?.statusCode else { return }
+                guard let value = dataResponse.value else { return }
+                print(value)
+                let networkResult = self.judge(by: statusCode, value)
+                completion(networkResult)
+            case .failure: completion(.networkFail)
+            }
+        }
+    }
+
     private func judge(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
         switch statusCode {
         case 200: return isData(by: data)

--- a/cozy/cozy/Source/API/Services/UpdateInterestService.swift
+++ b/cozy/cozy/Source/API/Services/UpdateInterestService.swift
@@ -1,0 +1,53 @@
+//
+//  UpdateInterestService.swift
+//  cozy
+//
+//  Created by 최은지 on 2020/09/09.
+//  Copyright © 2020 최은지. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+
+struct UpdateInterestService {
+    static let shared = UpdateInterestService()
+
+    func getMapListData(bookstoreIdx: Int, completion: @escaping (NetworkResult<Any>) -> Void) {
+
+        guard let token = UserDefaults.standard.string(forKey: "token") else {return}
+
+        let header: HTTPHeaders = [
+            "Content-Type": "application/json",
+            "token": token
+        ]
+
+        let dataRequest = AF.request(APIConstants.mypageInterestBookstoreURL + String(bookstoreIdx), method: .put, encoding: JSONEncoding.default, headers: header)
+
+        dataRequest.responseData { dataResponse in
+            switch dataResponse.result {
+            case .success:
+                guard let statusCode = dataResponse.response?.statusCode else { return }
+                guard let value = dataResponse.value else { return }
+                let networkResult = self.judge(by: statusCode, value)
+                completion(networkResult)
+            case .failure: completion(.networkFail)
+            }
+        }
+    }
+
+    private func judge(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
+        switch statusCode {
+        case 200: return isData(by: data)
+        case 400: return .pathErr
+        case 500: return .serverErr
+        default: return .networkFail
+        }
+    }
+
+    private func isData(by data: Data) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+        guard let decodedData = try? decoder.decode(UpdateInterestModel.self, from: data) else { return .pathErr }
+        guard let recommendData = decodedData.data else { return .requestErr(decodedData.message) }
+        return .success(recommendData)
+    }
+}

--- a/cozy/cozy/Source/ViewControllers/Login/LoginVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Login/LoginVC.swift
@@ -122,13 +122,18 @@ extension LoginVC: ASAuthorizationControllerDelegate {
     // 성공 후 동작
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
         if let credential = authorization.credential as? ASAuthorizationAppleIDCredential {
-            let user = credential.user
-            print(credential.authorizationCode)
-            print("user: ", user)
-            print("token: ", credential.identityToken)
 
-            guard let email = credential.email else { return }
-            print("email: ", email)
+            let idToken = credential.identityToken!
+            let tokeStr = String(data: idToken, encoding: .utf8)
+            print(tokeStr)
+
+            guard let code = credential.authorizationCode else { return }
+            let codeStr = String(data: code, encoding: .utf8)
+            print(codeStr)
+
+            let user = credential.user
+            print(user)
+
         }
     }
 

--- a/cozy/cozy/Source/ViewControllers/Login/LoginVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Login/LoginVC.swift
@@ -72,16 +72,17 @@ class LoginVC: UIViewController {
         // 웹 뷰로 카카오톡 로그인
         AuthApi.shared.loginWithKakaoAccount {(oauthToken, error) in
             if let error = error {
-                print(error)
+//                print(error)
             } else {
                 print("loginWithKakaoAccount() success.")
 
                 // 로그인 성공시 유저 정보 가져오기 - 이메일, 닉네임
                 UserApi.shared.me { (user, error) in
                     if let error = error {
-                        print(error)
+//                        print(error)
                     } else {
                         print("me() succeess")
+                        print(oauthToken!.refreshToken)
                         self.connectKakaoLogin(id: "\(user?.id)", nickname: (user?.kakaoAccount?.profile!.nickname)!, refreshToken: oauthToken!.refreshToken)
                     }
                 }
@@ -119,6 +120,7 @@ extension LoginVC: ASAuthorizationControllerDelegate {
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
         if let credential = authorization.credential as? ASAuthorizationAppleIDCredential {
             let user = credential.user
+            print(credential.authorizationCode)
             print("user: ", user)
             print("token: ", credential.identityToken)
 

--- a/cozy/cozy/Source/ViewControllers/Login/LoginVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Login/LoginVC.swift
@@ -21,10 +21,15 @@ class LoginVC: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
+        setUserDefaults()
         let gesture = UITapGestureRecognizer(target: self, action: #selector(clickKakaoSocialLogin(_:)))
         kakaoView.addGestureRecognizer(gesture)
         let gesture2 = UITapGestureRecognizer(target: self, action: #selector(clickAppleLogin(_:)))
         appleView.addGestureRecognizer(gesture2)
+    }
+
+    func setUserDefaults() {
+        UserDefaults.standard.set("", forKey: "token")
     }
 
     func setUI() {
@@ -42,8 +47,6 @@ class LoginVC: UIViewController {
     }
 
     @objc func clickAppleLogin(_ sender: UITapGestureRecognizer) {
-        print("click apple login")
-
         let request = ASAuthorizationAppleIDProvider().createRequest()
         request.requestedScopes = [.fullName, .email]
         let controller = ASAuthorizationController(authorizationRequests: [request])
@@ -56,34 +59,34 @@ class LoginVC: UIViewController {
     @objc func clickKakaoSocialLogin(_ sender: UITapGestureRecognizer) {
 
         // 카카오톡 설치 여부 확인
-//        if AuthApi.isKakaoTalkLoginAvailable() {
-//            AuthApi.shared.loginWithKakaoTalk {(oauthToken, error) in
-//                if let error = error {
-//                    print(error)
-//                } else {
-//                    print("loginWithKakaoTalk() success.")
-//
-//                    //do something
-//                    _ = oauthToken
-//                }
-//            }
-//        }
+        //        if AuthApi.isKakaoTalkLoginAvailable() {
+        //            AuthApi.shared.loginWithKakaoTalk {(oauthToken, error) in
+        //                if let error = error {
+        //                    print(error)
+        //                } else {
+        //                    print("loginWithKakaoTalk() success.")
+        //
+        //                    //do something
+        //                    _ = oauthToken
+        //                }
+        //            }
+        //        }
 
         // 웹 뷰로 카카오톡 로그인
         AuthApi.shared.loginWithKakaoAccount {(oauthToken, error) in
             if let error = error {
-//                print(error)
+                print(error)
             } else {
                 print("loginWithKakaoAccount() success.")
 
                 // 로그인 성공시 유저 정보 가져오기 - 이메일, 닉네임
                 UserApi.shared.me { (user, error) in
                     if let error = error {
-//                        print(error)
+                        print(error)
                     } else {
                         print("me() succeess")
                         print(oauthToken!.refreshToken)
-                        self.connectKakaoLogin(id: "\(user?.id)", nickname: (user?.kakaoAccount?.profile!.nickname)!, refreshToken: oauthToken!.refreshToken)
+                        self.connectKakaoLogin(id: "\(user!.id)", nickname: (user?.kakaoAccount?.profile!.nickname)!, refreshToken: oauthToken!.refreshToken)
                     }
                 }
             }

--- a/cozy/cozy/Source/ViewControllers/Recommend/VC/BookDetailVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/VC/BookDetailVC.swift
@@ -82,7 +82,10 @@ class BookDetailVC: UIViewController {
             switch NetworkResult {
             case .success(let data):
                 guard let data = data as? [RecommendFeedData] else { return }
-                print(data)
+                for data in data {
+                    self.feedList1.append(RecommendFeedData(image: data.image ?? "", text: data.text ?? ""))
+                }
+                self.detailTableView.reloadData()
             case .requestErr:
                 print("Request error")
             case .pathErr:
@@ -194,7 +197,7 @@ extension BookDetailVC: UITableViewDelegate, UITableViewDataSource, detailCell1D
             return self.detailList.count
         } else {
             if self.isClickBook {
-                return 3
+                return self.feedList1.count
             } else {
                 return self.feedList2.count/2
             }
@@ -261,6 +264,7 @@ extension BookDetailVC: UITableViewDelegate, UITableViewDataSource, detailCell1D
                 let cell = tableView.dequeueReusableCell(withIdentifier: detailIdentifier2) as! detailCell2
                 cell.selectionStyle = .none
                 cell.detailImageView.image = UIImage(named: "tuBongHKmBzQDkvgIUnsplash")
+                cell.detailLabel.text = self.feedList1[indexPath.row].text
                 return cell
             } else { // 활동 피드
                 let cell = tableView.dequeueReusableCell(withIdentifier: detailIdentifier3) as! detailCell3

--- a/cozy/cozy/Source/ViewControllers/Recommend/VC/RecommendVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/VC/RecommendVC.swift
@@ -21,12 +21,22 @@ class RecommendVC: UIViewController {
         tableView.delegate = self
         tableView.dataSource = self
         getRecommendListData()
+        isUserLoggedIN()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         if let index = self.tableView.indexPathForSelectedRow {
             self.tableView.deselectRow(at: index, animated: true)
+        }
+    }
+
+    func isUserLoggedIN() {
+        let str = UserDefaults.standard.object(forKey: "token") as! String
+        if str.count > 0 {
+            print("login")
+        } else {
+            print("notlogin")
         }
     }
 

--- a/cozy/cozy/Source/ViewControllers/Recommend/VC/RecommendVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/VC/RecommendVC.swift
@@ -52,6 +52,25 @@ class RecommendVC: UIViewController {
             }
         }
     }
+
+    private func updateInterest(bookstoreIdx: Int) {
+        UpdateInterestService.shared.getMapListData(bookstoreIdx: bookstoreIdx) { NetworkResult in
+            switch NetworkResult {
+            case.success(let data):
+                guard let data = data as? [UpdateInterestData] else { return }
+                print(data)
+            case .requestErr:
+                print("Request error")
+            case .pathErr:
+                print("path error")
+            case .serverErr:
+                print("server error")
+            case .networkFail:
+                print("network error")
+            }
+        }
+    }
+
 }
 
 extension RecommendVC: UITableViewDelegate, UITableViewDataSource, bookstoreDelegate {
@@ -59,17 +78,20 @@ extension RecommendVC: UITableViewDelegate, UITableViewDataSource, bookstoreDele
     func clickBookmarkButton(index: Int) {
         let indexPath = IndexPath(row: index, section: 1)
         let cell = self.tableView.cellForRow(at: indexPath) as! bookstoreCell
+        let bookstoreIdx = self.recommendList[index].bookstoreIdx
 
         if cell.bookmarkButton.hasImage(named: "iconsavewhite", for: .normal) {
             cell.bookmarkButton.setImage(UIImage(named: "iconsavefull"), for: .normal)
             let alert = UIAlertController(title: "콕!", message: "관심 책방에 등록되었습니다.", preferredStyle: UIAlertController.Style.alert)
             alert.addAction(UIAlertAction(title: "Ok", style: UIAlertAction.Style.default, handler: nil))
             self.present(alert, animated: true, completion: nil)
+            self.updateInterest(bookstoreIdx: bookstoreIdx!)
         } else {
             let cancelAlert = UIAlertController(title: "관심 책방에서 삭제하시겠어요?", message: "관심책방 등록을 삭제하시면, 관심책방에서 다시 볼 수 없어요.", preferredStyle: UIAlertController.Style.alert)
 
             cancelAlert.addAction(UIAlertAction(title: "네", style: .default, handler: { (_: UIAlertAction!) in
                 cell.bookmarkButton.setImage(UIImage(named: "iconsavewhite"), for: .normal)
+                self.updateInterest(bookstoreIdx: bookstoreIdx!)
             }))
 
             cancelAlert.addAction(UIAlertAction(title: "아니오", style: .cancel, handler: { (_: UIAlertAction!) in

--- a/cozy/cozy/Source/ViewControllers/Recommend/VC/RecommendVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/VC/RecommendVC.swift
@@ -21,22 +21,12 @@ class RecommendVC: UIViewController {
         tableView.delegate = self
         tableView.dataSource = self
         getRecommendListData()
-        isUserLoggedIN()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         if let index = self.tableView.indexPathForSelectedRow {
             self.tableView.deselectRow(at: index, animated: true)
-        }
-    }
-
-    func isUserLoggedIN() {
-        let str = UserDefaults.standard.object(forKey: "token") as! String
-        if str.count > 0 {
-            print("login")
-        } else {
-            print("notlogin")
         }
     }
 


### PR DESCRIPTION
1. 변경된 detail feed API 적용

2. 로그인 유저, 안 한 유저 구분

```swift
   func isUserLoggedIN() -> Bool {
        let str = UserDefaults.standard.object(forKey: "token") as! String
        if str.count > 0 {
            return true
        } else {
            return false
    }}
```

@yangg0228 @didwodnr123 참고하세요.

3. apple token encode

identity token encode로 access token, refresh token, authorization code, user identifier 읽어올 수 있음. 
그러나 이것은 iOS 13버전 이상부터 지원이라 그 이하 버전은 어떻게 처리해야할지 고민 중