### PR TITLE
MapVC nil 처리, 이벤트/공지사항 뷰 수정

### DIFF
--- a/cozy/cozy.xcodeproj/project.pbxproj
+++ b/cozy/cozy.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		B6C424B6250516E300AAE393 /* RecommendListService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C424B5250516E300AAE393 /* RecommendListService.swift */; };
 		B6C424B825054CFF00AAE393 /* BookstoreDetailModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C424B725054CFF00AAE393 /* BookstoreDetailModel.swift */; };
 		B6C424BA25054DD500AAE393 /* BookstoreDetailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C424B925054DD500AAE393 /* BookstoreDetailService.swift */; };
+		B6F2EE8E2514032B005CCF4C /* EventModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F2EE8D2514032B005CCF4C /* EventModel.swift */; };
 		B6F3CE02250FF70700B0A7CD /* NSNotification+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F3CE01250FF70700B0A7CD /* NSNotification+Extensions.swift */; };
 		B6F3CE04251005C500B0A7CD /* MypageInterestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F3CE03251005C500B0A7CD /* MypageInterestModel.swift */; };
 		B6F3CE06251006DD00B0A7CD /* MypageInterestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F3CE05251006DD00B0A7CD /* MypageInterestService.swift */; };
@@ -218,6 +219,7 @@
 		B6C424B5250516E300AAE393 /* RecommendListService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendListService.swift; sourceTree = "<group>"; };
 		B6C424B725054CFF00AAE393 /* BookstoreDetailModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookstoreDetailModel.swift; sourceTree = "<group>"; };
 		B6C424B925054DD500AAE393 /* BookstoreDetailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookstoreDetailService.swift; sourceTree = "<group>"; };
+		B6F2EE8D2514032B005CCF4C /* EventModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventModel.swift; sourceTree = "<group>"; };
 		B6F3CE01250FF70700B0A7CD /* NSNotification+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSNotification+Extensions.swift"; sourceTree = "<group>"; };
 		B6F3CE03251005C500B0A7CD /* MypageInterestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageInterestModel.swift; sourceTree = "<group>"; };
 		B6F3CE05251006DD00B0A7CD /* MypageInterestService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageInterestService.swift; sourceTree = "<group>"; };
@@ -454,6 +456,7 @@
 		B646AF7824EC033900AC96A9 /* Mypage */ = {
 			isa = PBXGroup;
 			children = (
+				B6F2EE8C251402D1005CCF4C /* Model */,
 				CC772907250B8A61001DB8FC /* VC */,
 				CC772906250B8A4A001DB8FC /* Cell */,
 			);
@@ -648,7 +651,6 @@
 				187C13072506559D004FD60B /* RecommendActivityModel.swift */,
 				B6208C9D25066BA700185624 /* MapCountModel.swift */,
 				B6208CA2250674E100185624 /* MapListModel.swift */,
-				CCBBD2DC25073FE4006A73FA /* NoticeModel.swift */,
 				B631283325075C01003D33E3 /* KakaoLoginModel.swift */,
 				B65058432507FB8F00D832E1 /* UpdateInterestModel.swift */,
 				187C1312250A1A2B004FD60B /* ActivityDetailModel.swift */,
@@ -660,6 +662,15 @@
 				B6F3CE03251005C500B0A7CD /* MypageInterestModel.swift */,
 			);
 			path = ResponseModel;
+			sourceTree = "<group>";
+		};
+		B6F2EE8C251402D1005CCF4C /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				CCBBD2DC25073FE4006A73FA /* NoticeModel.swift */,
+				B6F2EE8D2514032B005CCF4C /* EventModel.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		CC772906250B8A4A001DB8FC /* Cell */ = {
@@ -888,6 +899,7 @@
 				187C1315250B564A004FD60B /* ActivityDetailService.swift in Sources */,
 				B646AF4724EBFE4B00AC96A9 /* SceneDelegate.swift in Sources */,
 				187C1324250CBB4F004FD60B /* TastesService.swift in Sources */,
+				B6F2EE8E2514032B005CCF4C /* EventModel.swift in Sources */,
 				B646AF6A24EC00E900AC96A9 /* NetworkResult.swift in Sources */,
 				B658A3B1250156780076BCD4 /* onboardcell1.swift in Sources */,
 				B65058442507FB8F00D832E1 /* UpdateInterestModel.swift in Sources */,

--- a/cozy/cozy/Resource/Storyboard/Mypage/Mypage.storyboard
+++ b/cozy/cozy/Resource/Storyboard/Mypage/Mypage.storyboard
@@ -259,6 +259,9 @@
                                                         </constraints>
                                                         <fontDescription key="fontDescription" name="NanumSquareRoundB" family="NanumSquareRound" pointSize="16"/>
                                                         <state key="normal" title="로그인 하러 가기"/>
+                                                        <connections>
+                                                            <action selector="goLogin:" destination="GuZ-H9-OMw" eventType="touchUpInside" id="d6v-AA-opl"/>
+                                                        </connections>
                                                     </button>
                                                 </subviews>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>

--- a/cozy/cozy/Resource/Storyboard/Mypage/Mypage.storyboard
+++ b/cozy/cozy/Resource/Storyboard/Mypage/Mypage.storyboard
@@ -31,7 +31,7 @@
                                 <rect key="frame" x="0.0" y="88" width="414" height="725"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QnS-rU-C3R">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="588"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="584.5"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="HRJ-3j-FpN">
                                                 <rect key="frame" x="168" y="34" width="78" height="78"/>
@@ -41,44 +41,44 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="코지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jYa-yi-N3X">
-                                                <rect key="frame" x="193" y="128" width="28" height="19"/>
+                                                <rect key="frame" x="192.5" y="128" width="29.5" height="18"/>
                                                 <fontDescription key="fontDescription" name="NanumSquareRoundEB" family="NanumSquareRound" pointSize="16"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이메일이 없어요!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="arO-Di-quh">
-                                                <rect key="frame" x="154.5" y="153" width="105.5" height="19"/>
+                                                <rect key="frame" x="152" y="152" width="110.5" height="18"/>
                                                 <fontDescription key="fontDescription" name="NanumSquareRoundR" family="NanumSquareRound" pointSize="16"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconpick" translatesAutoresizingMaskIntoConstraints="NO" id="QFC-Jk-SmH">
-                                                <rect key="frame" x="196.5" y="208" width="21" height="24"/>
+                                                <rect key="frame" x="196.5" y="206" width="21" height="24"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="관심책방" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p1M-kU-u1S">
-                                                <rect key="frame" x="186" y="246" width="42" height="14"/>
+                                                <rect key="frame" x="185" y="244" width="44" height="13.5"/>
                                                 <fontDescription key="fontDescription" name="NanumSquareRoundB" family="NanumSquareRound" pointSize="12"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XOR-M8-fpS" userLabel="First Line Bar">
-                                                <rect key="frame" x="0.0" y="284" width="414" height="8"/>
+                                                <rect key="frame" x="0.0" y="281.5" width="414" height="8"/>
                                                 <color key="backgroundColor" red="0.96078431369999995" green="0.96078431369999995" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="8" id="e0S-z9-FWu"/>
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="최근 본 책방" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ysq-G8-LtZ">
-                                                <rect key="frame" x="24" y="320" width="78.5" height="19"/>
+                                                <rect key="frame" x="24" y="317.5" width="81" height="18"/>
                                                 <fontDescription key="fontDescription" name="NanumSquareRoundB" family="NanumSquareRound" pointSize="16"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BxY-TK-FPa">
-                                                <rect key="frame" x="0.0" y="344" width="414" height="170"/>
+                                                <rect key="frame" x="0.0" y="340.5" width="414" height="170"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="아직 최근 본 책방이 없어요!" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wgv-F7-0n2">
-                                                        <rect key="frame" x="131" y="77" width="152.5" height="16.5"/>
+                                                        <rect key="frame" x="128" y="77.5" width="158.5" height="15.5"/>
                                                         <fontDescription key="fontDescription" name="NanumSquareRoundR" family="NanumSquareRound" pointSize="14"/>
                                                         <color key="textColor" red="0.74117647060000003" green="0.74117647060000003" blue="0.74117647060000003" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -91,7 +91,7 @@
                                                 </constraints>
                                             </view>
                                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="t3o-ix-icU">
-                                                <rect key="frame" x="24" y="351" width="390" height="146"/>
+                                                <rect key="frame" x="24" y="347.5" width="390" height="146"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="146" id="7iq-uL-4z3"/>
@@ -119,7 +119,7 @@
                                                                     </constraints>
                                                                 </imageView>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tAq-V9-0eL">
-                                                                    <rect key="frame" x="0.0" y="122" width="34.5" height="16.5"/>
+                                                                    <rect key="frame" x="0.0" y="122" width="35.5" height="15.5"/>
                                                                     <fontDescription key="fontDescription" name="NanumSquareRoundR" family="NanumSquareRound" pointSize="14"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -142,14 +142,14 @@
                                                 </cells>
                                             </collectionView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7Sc-Oj-CdW" userLabel="Second Line Bar">
-                                                <rect key="frame" x="0.0" y="529" width="414" height="3"/>
+                                                <rect key="frame" x="0.0" y="525.5" width="414" height="3"/>
                                                 <color key="backgroundColor" red="0.96078431369999995" green="0.96078431369999995" blue="0.96078431369999995" alpha="1" colorSpace="calibratedRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="3" id="OsS-Nw-53S"/>
                                                 </constraints>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="i3g-f1-cMa">
-                                                <rect key="frame" x="0.0" y="552" width="414" height="16"/>
+                                                <rect key="frame" x="0.0" y="548.5" width="414" height="16"/>
                                                 <subviews>
                                                     <view tag="1" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rDC-FU-qu6">
                                                         <rect key="frame" x="0.0" y="0.0" width="207" height="16"/>
@@ -166,7 +166,7 @@
                                                                 </constraints>
                                                             </view>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="공지사항" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JS7-cz-Mw9">
-                                                                <rect key="frame" x="82" y="0.0" width="48.5" height="16.5"/>
+                                                                <rect key="frame" x="82" y="0.5" width="51" height="15.5"/>
                                                                 <fontDescription key="fontDescription" name="NanumSquareRoundB" family="NanumSquareRound" pointSize="14"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -202,7 +202,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이벤트" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HaH-PD-kqh">
-                                                                <rect key="frame" x="85" y="0.0" width="36.5" height="16.5"/>
+                                                                <rect key="frame" x="85" y="0.5" width="38.5" height="15.5"/>
                                                                 <fontDescription key="fontDescription" name="NanumSquareRoundB" family="NanumSquareRound" pointSize="14"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -231,7 +231,7 @@
                                                 </constraints>
                                             </stackView>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4vP-wN-gNS">
-                                                <rect key="frame" x="174.5" y="202" width="65" height="60"/>
+                                                <rect key="frame" x="174.5" y="200" width="65" height="60"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="65" id="ihH-CX-zfP"/>
                                                     <constraint firstAttribute="height" constant="60" id="ory-xo-Z2U"/>
@@ -241,10 +241,10 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" restorationIdentifier="before1" translatesAutoresizingMaskIntoConstraints="NO" id="Lz3-cD-fT0">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="192"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="190"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gg7-Sl-OaH">
-                                                        <rect key="frame" x="139.5" y="136" width="135" height="28"/>
+                                                        <rect key="frame" x="137" y="136" width="140.5" height="27"/>
                                                         <string key="text">내 정보 서비스를 이용하려면
 로그인이 필요해요!</string>
                                                         <fontDescription key="fontDescription" name="NanumSquareRoundR" family="NanumSquareRound" pointSize="12"/>
@@ -355,7 +355,7 @@
         <scene sceneID="sTi-9p-6DY">
             <objects>
                 <tableViewController storyboardIdentifier="NoticeVC" hidesBottomBarWhenPushed="YES" id="J2m-uW-aNf" customClass="NoticeVC" customModule="cozy" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="E0W-Ry-WVK">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="E0W-Ry-WVK">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
@@ -367,8 +367,8 @@
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="67"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="업데이트 권장 안내" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TQk-mK-CRw">
-                                            <rect key="frame" x="24" y="18" width="109" height="15.5"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TQk-mK-CRw">
+                                            <rect key="frame" x="24" y="18" width="36" height="15.5"/>
                                             <fontDescription key="fontDescription" name="NanumSquareRoundB" family="NanumSquareRound" pointSize="14"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -409,7 +409,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="136"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="content" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0TP-zl-RRP">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="content" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0TP-zl-RRP">
                                             <rect key="frame" x="44" y="31" width="320" height="15.5"/>
                                             <fontDescription key="fontDescription" name="NanumSquareRoundR" family="NanumSquareRound" pointSize="14"/>
                                             <nil key="textColor"/>
@@ -445,7 +445,7 @@
         <scene sceneID="FMj-JJ-aAF">
             <objects>
                 <tableViewController storyboardIdentifier="EventVC" id="s4F-9C-IF1" customClass="EventVC" customModule="cozy" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="kG9-YP-n5u">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="kG9-YP-n5u">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
@@ -489,15 +489,15 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="eventContentCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="eventContentCell" id="6He-Jg-VeQ" customClass="eventContentCell" customModule="cozy" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="88" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="6He-Jg-VeQ" id="39n-wm-a02">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ca9-pk-2Ze">
-                                            <rect key="frame" x="24" y="20" width="360" height="20.5"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ca9-pk-2Ze">
+                                            <rect key="frame" x="24" y="20" width="360" height="15.5"/>
+                                            <fontDescription key="fontDescription" name="NanumSquareRoundR" family="NanumSquareRound" pointSize="14"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>

--- a/cozy/cozy/Source/ViewControllers/MainTabVC.swift
+++ b/cozy/cozy/Source/ViewControllers/MainTabVC.swift
@@ -12,18 +12,6 @@ class MainTabVC: UITabBarController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
     }
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
 
 }

--- a/cozy/cozy/Source/ViewControllers/Map/VC/MapVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Map/VC/MapVC.swift
@@ -101,7 +101,8 @@ class MapVC: UIViewController {
                 }
                 self.mapTableView.reloadData()
             case .requestErr:
-                print("Request error")
+                self.mapList.removeAll()
+                self.mapTableView.reloadData()
             case .pathErr:
                 print("path error")
             case .serverErr:
@@ -123,7 +124,8 @@ class MapVC: UIViewController {
                 }
                 self.mapTableView.reloadData()
             case .requestErr:
-                print("Request error")
+                self.mapList.removeAll()
+                self.mapTableView.reloadData()
             case .pathErr:
                 print("path error")
             case .serverErr:
@@ -139,7 +141,7 @@ class MapVC: UIViewController {
             switch NetworkResult {
             case.success(let data):
                 guard let data = data as? UpdateInterestData else { return }
-                print("Update Interest🌟")
+                print(data)
             case .requestErr:
                 print("Request error")
             case .pathErr:

--- a/cozy/cozy/Source/ViewControllers/Mypage/Cell/eventTitleCell.swift
+++ b/cozy/cozy/Source/ViewControllers/Mypage/Cell/eventTitleCell.swift
@@ -13,15 +13,13 @@ class eventTitleCell: UITableViewCell {
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var dateLabel: UILabel!
     @IBOutlet weak var arrowImg: UIImageView!
+
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
     }
 
 }

--- a/cozy/cozy/Source/ViewControllers/Mypage/Cell/noticeContentCell.swift
+++ b/cozy/cozy/Source/ViewControllers/Mypage/Cell/noticeContentCell.swift
@@ -12,16 +12,12 @@ class noticeContentCell: UITableViewCell {
 
     @IBOutlet weak var contentTextView: UILabel!
 
-//    @IBOutlet var contentTextView: [UILabel]!
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
     }
 
 }

--- a/cozy/cozy/Source/ViewControllers/Mypage/Model/EventModel.swift
+++ b/cozy/cozy/Source/ViewControllers/Mypage/Model/EventModel.swift
@@ -1,0 +1,21 @@
+//
+//  EventModel.swift
+//  cozy
+//
+//  Created by 최은지 on 2020/09/18.
+//  Copyright © 2020 최은지. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+struct EventModel {
+    var date: String
+    var title: String
+    var content: String
+    var open = false
+
+    mutating func dateFormat() -> String { guard let s = self.date.split(separator: " ").first else { return "??" }
+        return String(s)
+    }
+}

--- a/cozy/cozy/Source/ViewControllers/Mypage/Model/NoticeModel.swift
+++ b/cozy/cozy/Source/ViewControllers/Mypage/Model/NoticeModel.swift
@@ -13,14 +13,9 @@ struct NoticeModel {
     var date: String
     var title: String
     var content: String
-
-//    let date: String
-//    let title: String
-//    let content: String
     var open = false
-    mutating func dateFormat() -> String { guard let s = self.date.split(separator: " ").first else {return "??"}
+
+    mutating func dateFormat() -> String { guard let s = self.date.split(separator: " ").first else { return "??" }
         return String(s)
-
     }
-
 }

--- a/cozy/cozy/Source/ViewControllers/Mypage/VC/EventVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Mypage/VC/EventVC.swift
@@ -11,79 +11,85 @@ import UIKit
 class EventVC: UIViewController {
 
     @IBOutlet var tableView: UITableView!
-    private var noticeData: [NoticeModel] = []
-    private func setNoticeData() {
-        let notice1 = NoticeModel(date: "20-00-08", title: "업데이트 권장", content: "s")
-        let notice2 = NoticeModel(date: "s", title: "s", content: "s")
-
-        noticeData = [notice1, notice2]
-    }
+    private var eventData: [EventModel] = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.delegate = self
         tableView.dataSource = self
         setNoticeData()
+        setNav()
     }
 
+    func setNav() {
+        self.navigationItem.setHidesBackButton(true, animated: true)
+        self.navigationController?.navigationBar.tintColor = UIColor.gray
+        let backButton = UIBarButtonItem(image: UIImage(named: "iconbefore"), style: .plain, target: self, action: #selector(goBack))
+        self.navigationItem.leftBarButtonItem = backButton
+    }
+
+    @objc func goBack() {
+        self.navigationController?.popViewController(animated: true)
+    }
+
+    private func setNoticeData() {
+        let event1 = EventModel(date: "20-09-18", title: "이벤트 공지사항", content: "코지 첫 런칭 이벤트가 준비중입니다. 조금만 기다려 주세요 :) ")
+        eventData = [event1]
+    }
 }
 
 extension EventVC: UITableViewDelegate, UITableViewDataSource {
 
     func numberOfSections(in tableView: UITableView) -> Int {
-         return noticeData.count
-     }
-
-     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-         if noticeData[section].open == true {
-             return 1 + 1
-         } else { return 1 }
-
-     }
-
-     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        if indexPath.row == 0 {
-            return 67
-        } else { return 136 }
-
+        return eventData.count
     }
 
-     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-         if indexPath.row == 0 {
-             let cell: eventTitleCell = tableView.dequeueReusableCell(withIdentifier: "eventTitleCell", for: indexPath) as! eventTitleCell
-             cell.titleLabel.text = noticeData[indexPath.section].title
-             cell.dateLabel.text = noticeData[indexPath.section].dateFormat()
-             return cell
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if eventData[section].open == true {
+            return 1 + 1
+        } else {
+            return 1
+        }
+    }
 
-         } else {
-             //클릭시 펼쳐질 셀
-             let cell: eventContentCell = tableView.dequeueReusableCell(withIdentifier: "eventContentCell", for: indexPath) as! eventContentCell
-             cell.contentTextView.text = noticeData[indexPath.section].content
-             return cell
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        if indexPath.row == 0 {
+            return 67
+        } else {
+            return 120
+        }
+    }
 
-         }
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        if indexPath.row == 0 {
+            let cell: eventTitleCell = tableView.dequeueReusableCell(withIdentifier: "eventTitleCell", for: indexPath) as! eventTitleCell
+            cell.titleLabel.text = eventData[indexPath.section].title
+            cell.dateLabel.text = eventData[indexPath.section].dateFormat()
+            return cell
 
-     }
-     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-         guard let cell = tableView.cellForRow(at: indexPath) as? eventTitleCell
-             else {return}
-         guard let index = tableView.indexPath(for: cell) else { return }
-         if index.row == indexPath.row {
-             if index.row == 0 {
-                 if noticeData[indexPath.section].open == true {
-                     noticeData[indexPath.section].open = false
+        } else {
+            let cell: eventContentCell = tableView.dequeueReusableCell(withIdentifier: "eventContentCell", for: indexPath) as! eventContentCell
+            cell.contentTextView.text = eventData[indexPath.section].content
+            return cell
+        }
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let cell = tableView.cellForRow(at: indexPath) as? eventTitleCell else { return }
+        guard let index = tableView.indexPath(for: cell) else { return }
+        if index.row == indexPath.row {
+            if index.row == 0 {
+                if eventData[indexPath.section].open == true {
+                    eventData[indexPath.section].open = false
                     cell.arrowImg.image = UIImage(named: "iconfold8X14")
-                     let section = IndexSet.init(integer: indexPath.section)
-
-                     tableView.reloadSections(section, with: .fade)
-
-                 } else { noticeData[indexPath.section].open = true
+                    let section = IndexSet.init(integer: indexPath.section)
+                    tableView.reloadSections(section, with: .fade)
+                } else {
+                    eventData[indexPath.section].open = true
                     cell.arrowImg.image = UIImage(named: "iconmore8X14")
-                     let section = IndexSet.init(integer: indexPath.section)
-                     tableView.reloadSections(section, with: .fade) }
-
-             }
-
-         }
-     }
+                    let section = IndexSet.init(integer: indexPath.section)
+                    tableView.reloadSections(section, with: .fade) }
+            }
+        }
+    }
 }

--- a/cozy/cozy/Source/ViewControllers/Mypage/VC/MypageVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Mypage/VC/MypageVC.swift
@@ -131,6 +131,10 @@ class MypageVC: UIViewController {
         self.navigationController?.pushViewController(vc, animated: true)
     }
 
+    @IBAction func goLogin(_ sender: UIButton) {
+        self.dismiss(animated: true, completion: nil)
+    }
+
 }
 
 extension MypageVC: UICollectionViewDataSource {

--- a/cozy/cozy/Source/ViewControllers/Mypage/VC/NoticeVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Mypage/VC/NoticeVC.swift
@@ -12,78 +12,84 @@ class NoticeVC: UIViewController {
 
     @IBOutlet var tableView: UITableView!
     private var noticeData: [NoticeModel] = []
-    private func setNoticeData() {
-        let notice1 = NoticeModel(date: "20-00-08", title: "업데이트 권장", content: "s")
-        let notice2 = NoticeModel(date: "s", title: "s", content: "s")
-
-        noticeData = [notice1, notice2]
-    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.delegate = self
         tableView.dataSource = self
         setNoticeData()
+        setNav()
     }
 
+    func setNav() {
+        self.navigationItem.setHidesBackButton(true, animated: true)
+        self.navigationController?.navigationBar.tintColor = UIColor.gray
+        let backButton = UIBarButtonItem(image: UIImage(named: "iconbefore"), style: .plain, target: self, action: #selector(goBack))
+        self.navigationItem.leftBarButtonItem = backButton
+    }
+
+    @objc func goBack() {
+        self.navigationController?.popViewController(animated: true)
+    }
+
+    private func setNoticeData() {
+        let notice1 = NoticeModel(date: "20-09-19", title: "업데이트 권장", content: "코지 첫 공지입니다. 독립서점 어플 코지가 첫 런칭을 시작했습니다. 버그 발견시 리뷰나 이메일로 연락 주세요 :) ")
+        noticeData = [notice1]
+    }
 }
 
 extension NoticeVC: UITableViewDelegate, UITableViewDataSource {
 
     func numberOfSections(in tableView: UITableView) -> Int {
-         return noticeData.count
-     }
-
-     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-         if noticeData[section].open == true {
-             return 1 + 1
-         } else { return 1 }
-
-     }
-
-     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        if indexPath.row == 0 {
-            return 67
-        } else { return 136 }
-
+        return noticeData.count
     }
 
-     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-         if indexPath.row == 0 {
-             let cell: noticeTitleCell = tableView.dequeueReusableCell(withIdentifier: "noticeTitleCell", for: indexPath) as! noticeTitleCell
-             cell.titleLabel.text = noticeData[indexPath.section].title
-             cell.dateLabel.text = noticeData[indexPath.section].dateFormat()
-             return cell
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if noticeData[section].open == true {
+            return 2
+        } else {
+            return 1
+        }
+    }
 
-         } else {
-             //클릭시 펼쳐질 셀
-             let cell: noticeContentCell = tableView.dequeueReusableCell(withIdentifier: "noticeContentCell", for: indexPath) as! noticeContentCell
-             cell.contentTextView.text = noticeData[indexPath.section].content
-             return cell
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        if indexPath.row == 0 {
+            return 67
+        } else {
+            return 120
+        }
+    }
 
-         }
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        if indexPath.row == 0 {
+            let cell: noticeTitleCell = tableView.dequeueReusableCell(withIdentifier: "noticeTitleCell", for: indexPath) as! noticeTitleCell
+            cell.titleLabel.text = noticeData[indexPath.section].title
+            cell.dateLabel.text = noticeData[indexPath.section].dateFormat()
+            return cell
 
-     }
-     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-         guard let cell = tableView.cellForRow(at: indexPath) as? noticeTitleCell
-             else {return}
-         guard let index = tableView.indexPath(for: cell) else { return }
-         if index.row == indexPath.row {
-             if index.row == 0 {
-                 if noticeData[indexPath.section].open == true {
-                     noticeData[indexPath.section].open = false
+        } else {
+            let cell: noticeContentCell = tableView.dequeueReusableCell(withIdentifier: "noticeContentCell", for: indexPath) as! noticeContentCell
+            cell.contentTextView.text = noticeData[indexPath.section].content
+            return cell
+        }
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let cell = tableView.cellForRow(at: indexPath) as? noticeTitleCell else { return }
+        guard let index = tableView.indexPath(for: cell) else { return }
+        if index.row == indexPath.row {
+            if index.row == 0 {
+                if noticeData[indexPath.section].open == true {
+                    noticeData[indexPath.section].open = false
                     cell.arrowImg.image = UIImage(named: "iconfold8X14")
-                     let section = IndexSet.init(integer: indexPath.section)
-
-                     tableView.reloadSections(section, with: .fade)
-
-                 } else { noticeData[indexPath.section].open = true
+                    let section = IndexSet.init(integer: indexPath.section)
+                    tableView.reloadSections(section, with: .fade)
+                } else {
+                    noticeData[indexPath.section].open = true
                     cell.arrowImg.image = UIImage(named: "iconmore8X14")
-                     let section = IndexSet.init(integer: indexPath.section)
-                     tableView.reloadSections(section, with: .fade) }
-
-             }
-
-         }
-     }
+                    let section = IndexSet.init(integer: indexPath.section)
+                    tableView.reloadSections(section, with: .fade) }
+            }
+        }
+    }
 }

--- a/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell2.xib
+++ b/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell2.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -27,7 +27,7 @@
                             <constraint firstAttribute="height" constant="303" id="0OU-6F-pzK"/>
                         </constraints>
                     </imageView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MQ7-1A-Pn2">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MQ7-1A-Pn2">
                         <rect key="frame" x="24" y="323" width="272" height="15.5"/>
                         <fontDescription key="fontDescription" name="NanumSquareRoundL" family="NanumSquareRound" pointSize="14"/>
                         <nil key="textColor"/>

--- a/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell3.xib
+++ b/cozy/cozy/Source/ViewControllers/Recommend/Cell/detailCell3.xib
@@ -36,8 +36,8 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SJq-hS-9Vs">
-                                        <rect key="frame" x="24" y="166" width="34.5" height="15.5"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SJq-hS-9Vs">
+                                        <rect key="frame" x="24" y="166" width="126" height="15.5"/>
                                         <fontDescription key="fontDescription" name="NanumSquareRoundL" family="NanumSquareRound" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -83,6 +83,7 @@
                                     <constraint firstItem="SJq-hS-9Vs" firstAttribute="top" secondItem="44S-2U-yCN" secondAttribute="bottom" constant="6" id="Ug7-09-n3k"/>
                                     <constraint firstAttribute="bottom" secondItem="jV2-Du-uLm" secondAttribute="bottom" constant="40" id="aMy-O7-jUl"/>
                                     <constraint firstItem="VIH-VD-LPS" firstAttribute="top" secondItem="h5D-Wq-7K4" secondAttribute="top" constant="10" id="eeQ-TK-WBF"/>
+                                    <constraint firstAttribute="trailing" secondItem="SJq-hS-9Vs" secondAttribute="trailing" constant="10" id="kCa-BU-QSG"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kki-ZR-xLx">
@@ -94,8 +95,8 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RU8-JF-6Vw">
-                                        <rect key="frame" x="10" y="166" width="34.5" height="15.5"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RU8-JF-6Vw">
+                                        <rect key="frame" x="10" y="166" width="140" height="15.5"/>
                                         <fontDescription key="fontDescription" name="NanumSquareRoundL" family="NanumSquareRound" pointSize="14"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -139,6 +140,7 @@
                                     <constraint firstAttribute="bottom" secondItem="2lT-Mf-pVQ" secondAttribute="bottom" constant="40" id="giO-h3-eHV"/>
                                     <constraint firstItem="Jho-nL-4r9" firstAttribute="leading" secondItem="Kki-ZR-xLx" secondAttribute="leading" constant="10" id="ipY-DP-AA9"/>
                                     <constraint firstItem="tZ7-jk-Zit" firstAttribute="leading" secondItem="Kki-ZR-xLx" secondAttribute="leading" constant="20" id="nAl-i1-UfN"/>
+                                    <constraint firstAttribute="trailing" secondItem="RU8-JF-6Vw" secondAttribute="trailing" constant="10" id="nU2-c8-2fY"/>
                                     <constraint firstItem="Jho-nL-4r9" firstAttribute="top" secondItem="s1n-wQ-hJw" secondAttribute="bottom" constant="16" id="q55-zf-4KK"/>
                                 </constraints>
                             </view>

--- a/cozy/cozy/Source/ViewControllers/Recommend/VC/BookDetailVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/VC/BookDetailVC.swift
@@ -131,7 +131,8 @@ class BookDetailVC: UIViewController {
                 }
                 self.detailTableView.reloadData()
             case .requestErr:
-                print("Request error")
+                self.feedList1.removeAll()
+                self.detailTableView.reloadData()
             case .pathErr:
                 print("path error")
             case .serverErr:
@@ -151,7 +152,8 @@ class BookDetailVC: UIViewController {
                     self.feedList2.append(RecommendActivityData(activityIdx: data.activityIdx, activityName: data.activityName ?? "", shortIntro: data.shortIntro ?? "", image1: data.image1 ?? "", price: data.price ?? 0, dday: data.activityIdx))
                 }
             case .requestErr:
-                print("Request error")
+                self.feedList2.removeAll()
+                self.detailTableView.reloadData()
             case .pathErr:
                 print("path error")
             case .serverErr:
@@ -351,7 +353,14 @@ extension BookDetailVC: UITableViewDelegate, UITableViewDataSource, detailCell1D
             if isClickBook { // 책방 피드
                 let cell = tableView.dequeueReusableCell(withIdentifier: detailIdentifier2) as! detailCell2
                 cell.selectionStyle = .none
-                cell.detailImageView.image = UIImage(named: "tuBongHKmBzQDkvgIUnsplash")
+
+                if self.feedList1[indexPath.row].image?.count == 0 {
+                    cell.detailImageView.image = UIImage(named: "tuBongHKmBzQDkvgIUnsplash")
+                } else {
+                    let feedimgurl = URL(string: self.feedList1[indexPath.row].image!)
+                    cell.detailImageView.kf.setImage(with: feedimgurl)
+                }
+
                 cell.detailLabel.text = self.feedList1[indexPath.row].text
                 return cell
             } else { // 활동 피드
@@ -359,10 +368,23 @@ extension BookDetailVC: UITableViewDelegate, UITableViewDataSource, detailCell1D
                 cell.selectionStyle = .none
                 cell.delegate = self
 
-                cell.imageButton1.setBackgroundImage(UIImage(named: "ajeetMestryUBhpOiHnazMUnsplash"), for: .normal)
-                cell.imageButton2.setBackgroundImage(UIImage(named: "ajeetMestryUBhpOiHnazMUnsplash"), for: .normal)
+                if self.feedList2[indexPath.row].image1?.count == 0 {
+                    cell.imageButton1.setBackgroundImage(UIImage(named: "ajeetMestryUBhpOiHnazMUnsplash"), for: .normal)
+                } else {
+                    let feed2url1 = URL(string: self.feedList2[indexPath.row].image1!)
+                    cell.imageButton1.kf.setImage(with: feed2url1, for: .normal)
+                }
+
+                if self.feedList2[indexPath.row+1].image1?.count == 0 {
+                    cell.imageButton2.setBackgroundImage(UIImage(named: "ajeetMestryUBhpOiHnazMUnsplash"), for: .normal)
+                } else {
+                    let feed2url2 = URL(string: self.feedList2[indexPath.row+1].image1!)
+                    cell.imageButton2.kf.setImage(with: feed2url2, for: .normal)
+                }
+
                 cell.nameLabel1.text = self.feedList2[indexPath.row].activityName
                 cell.nameLabel2.text = self.feedList2[indexPath.row+1].activityName
+
                 cell.descripLabel1.text = self.feedList2[indexPath.row].shortIntro
                 cell.descripLabel2.text = self.feedList2[indexPath.row+1].shortIntro
                 cell.daycntLabel1.text = "D-\(self.feedList2[indexPath.row].dday!)"

--- a/cozy/cozy/Source/ViewControllers/Recommend/VC/RecommendVC.swift
+++ b/cozy/cozy/Source/ViewControllers/Recommend/VC/RecommendVC.swift
@@ -61,7 +61,7 @@ class RecommendVC: UIViewController {
                 }
                 self.recommendList.removeAll()
                 for data in data {
-                    self.recommendList.append(RecommendListData(bookstoreIdx: data.bookstoreIdx ?? 0, bookstoreName: data.bookstoreName ?? "", mainImg: data.mainImg ?? "", shortIntro1: data.shortIntro1 ?? "", shortIntro2: data.shortIntro2 ?? "", location: data.location ?? "", hashtag1: data.hashtag1 ?? "", hashtag2: data.hashtag2 ?? "", hashtag3: data.hashtag3 ?? "", checked: data.checked ?? 0))
+                    self.recommendList.append(RecommendListData(bookstoreIdx: data.bookstoreIdx ?? 0, bookstoreName: data.bookstoreName ?? "", mainImg: data.mainImg ?? "", shortIntro1: data.shortIntro1 ?? "", shortIntro2: data.shortIntro2 ?? "", location: data.location ?? "", hashtag1: data.hashtag1 ?? "코지와", hashtag2: data.hashtag2 ?? "함께하는", hashtag3: data.hashtag3 ?? "책방", checked: data.checked ?? 0))
                 }
                 self.tableView.reloadData()
             case .requestErr:
@@ -83,7 +83,7 @@ class RecommendVC: UIViewController {
                 guard let data = data as? [RecommendListData] else { return }
                 self.recommendList.removeAll()
                 for data in data {
-                    self.recommendList.append(RecommendListData(bookstoreIdx: data.bookstoreIdx ?? 0, bookstoreName: data.bookstoreName ?? "", mainImg: data.mainImg ?? "", shortIntro1: data.shortIntro1 ?? "", shortIntro2: data.shortIntro2 ?? "", location: data.location ?? "", hashtag1: data.hashtag1 ?? "", hashtag2: data.hashtag2 ?? "", hashtag3: data.hashtag3 ?? "", checked: data.checked ?? 0))
+                    self.recommendList.append(RecommendListData(bookstoreIdx: data.bookstoreIdx ?? 0, bookstoreName: data.bookstoreName ?? "", mainImg: data.mainImg ?? "", shortIntro1: data.shortIntro1 ?? "", shortIntro2: data.shortIntro2 ?? "", location: data.location ?? "", hashtag1: data.hashtag1 ?? "코지와", hashtag2: data.hashtag2 ?? "함께하는", hashtag3: data.hashtag3 ?? "책방", checked: data.checked ?? 0))
                 }
                 self.tableView.reloadData()
             case .requestErr:


### PR DESCRIPTION
1. 드디어 지역별 독립서점 개수가 0일때 에러처리를 했다. 

request error 부분에 
```swift
datalist.removeAll() // 데이터가 0개 이므로 모두 삭제
tableview.reload() // 테이블 리로드
```
생각보다 간단하게  해결

2. 책방 피드, 활동 피드의 짜잘한 버그 해결

3. 이벤트, 공지사항 VC 수정. 근데 기획측에서 상세 이벤트/공지사항 데이터를 제공하지 않아 의미가 있나 싶긴 하다 개수가 너무 적어서..

---

### 현재 남은 가장 큰 버그

1. 최근 본 책방이 갑자기 안 뜨기 시작함 ㅜ ... 나 울어
2. 관심 책방 ..